### PR TITLE
Selectors with fixed deterministic endpoints

### DIFF
--- a/tests/test_Kernels.py
+++ b/tests/test_Kernels.py
@@ -58,7 +58,9 @@ class TestKernels(unittest.TestCase):
             for sel in (
                     selectors.FixedStepSizeSelector(),
                     selectors.AsymmetricSelector(),
-                    selectors.SymmetricSelector()
+                    selectors.SymmetricSelector(),
+                    selectors.DeterministicAsymmetricSelector(),
+                    selectors.DeterministicSymmetricSelector()
                 ):
                 with self.subTest(kernel_class=kernel_class, sel=sel):
                     rng_key, run_key = random.split(rng_key)


### PR DESCRIPTION
Stabilizes and shortens the running time by avoiding entering the autostep loop unless the acceptance probability is too low or too high in absolute terms. The default (0.1, 0.9) works well in practice, and results in ~15% decrease in running time in well behaved models. Haven't tested it in a truly "house-of-horrors" target though.

My idea is to be able to run the simple AutoHMC with fixed #leapfrog steps >>1 without having to redo the whole trajectory unless strictly necessary.