### PR TITLE
stronger regularization of sample vars + clean up

### DIFF
--- a/autostep/preconditioning.py
+++ b/autostep/preconditioning.py
@@ -39,7 +39,7 @@ class MixDiagonalPreconditioner(Preconditioner):
 
     @staticmethod
     def build_precond(sqrt_var, rng_key):
-        assert len(jnp.shape(sqrt_var)) == 1
+        assert jnp.ndim(sqrt_var) == 1
 
         # uniform mixture in log space
         # p = exp(U*log(hat_sd) + (1-U)log(1)) = exp(log(hat_sd^U))) = hat_sd^U
@@ -59,7 +59,7 @@ class MixDensePreconditioner(Preconditioner):
 
     @staticmethod
     def build_precond(sqrt_var, rng_key):
-        assert len(jnp.shape(sqrt_var)) == 2
+        assert jnp.ndim(sqrt_var) == 2
 
         # with equal prob choose the estimate or the identity
         return lax.cond(

--- a/autostep/tempering.py
+++ b/autostep/tempering.py
@@ -6,7 +6,7 @@ from jax import numpy as jnp
 
 from numpyro.handlers import substitute, trace
 from numpyro.infer import util
-from numpyro.distributions.util import is_identically_one, is_identically_zero
+from numpyro.distributions.util import is_identically_one
 
 
 ##############################################################################
@@ -82,7 +82,6 @@ def trace_from_unconst_samples(
     return trace(substituted_model).get_trace(*model_args, **model_kwargs)
 
 # tempered potential of a model
-@partial(jax.jit, static_argnums=(0,))
 def tempered_potential(model, model_args, model_kwargs, unconstrained_sample, inv_temp = None):
     """
     Build a tempered version of the potential function associated with the

--- a/autostep/utils.py
+++ b/autostep/utils.py
@@ -22,11 +22,9 @@ def proto_checkified_is_zero(x):
 
 checkified_is_zero = checkify.checkify(proto_checkified_is_zero)
 
-@jax.jit
 def std_normal_potential(v):
     return (v*v).sum()/2
 
-@jax.jit
 def ceil_log2(x):
     """
     Ceiling of log2(x). Guaranteed to be an integer.
@@ -34,7 +32,6 @@ def ceil_log2(x):
     n_bits = jax.lax.clz(jnp.zeros_like(x))
     return n_bits - jax.lax.clz(x) - (jax.lax.population_count(x)==1)
 
-@jax.jit
 def apply_precond(precond_array, vec):
     return (
         precond_array * vec 
@@ -42,7 +39,6 @@ def apply_precond(precond_array, vec):
         else precond_array @ vec
     )
 
-@jax.jit
 def numerically_safe_diff(x0, x1):
     """
     Return `x1-x0` if x1 is not the next float after x0, and 0 otherwise.

--- a/tests/test_AutoHMC.py
+++ b/tests/test_AutoHMC.py
@@ -25,3 +25,4 @@ class TestAutoHMC(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    

--- a/tests/test_Kernels.py
+++ b/tests/test_Kernels.py
@@ -9,11 +9,9 @@ from jax import numpy as jnp
 
 from numpyro.infer import MCMC
 
-from autostep import autostep
 from autostep import autohmc
 from autostep import autorwmh
 from autostep import selectors
-from autostep import statistics
 from autostep import utils
 
 

--- a/tests/test_tempering.py
+++ b/tests/test_tempering.py
@@ -1,19 +1,14 @@
 from tests import utils as testutils
 
-from functools import partial
 import unittest
 
-import jax
 from jax import random
 from jax import numpy as jnp
 
 from numpyro.infer import MCMC
 
-from autostep import autostep
 from autostep import autohmc
 from autostep import autorwmh
-from autostep import selectors
-from autostep import statistics
 from autostep import utils
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,6 @@ def make_const_off_diag_corr_mat(dim, rho):
 def make_correlated_Gaussian_potential(S=None, dim=None, rho=None):
     S = make_const_off_diag_corr_mat(dim, rho) if S is None else S
     P = jnp.linalg.inv(S)
-    @jax.jit
     def pot_fn(x):
         return 0.5*jnp.dot(x.T, jnp.dot(P, x))
     return pot_fn


### PR DESCRIPTION
Using the same magic formula they use in [numpyro](https://github.com/pyro-ppl/numpyro/blob/ab1f0dc6e954ef7d54724386667e33010b2cfc8b/numpyro/infer/hmc_util.py#L219), which in turn seems to come from Stan.

Also deleted all of the jax.jit statements since these are superfluous -- eventually the whole sample step is jitted regardless.