### PR TITLE
Overhaul the preconditioning interface

### DIFF
--- a/autostep/autohmc.py
+++ b/autostep/autohmc.py
@@ -146,7 +146,7 @@ def gen_integrator(tempered_potential, initial_state):
         x_flat    = flatten_util.ravel_pytree(x)[0]
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
         # jax.debug.print("pre 1st momentum half-step: x={x}, x_flat={xf}, grad={g}, p_flat={v}", ordered=True, x=x, xf=x_flat, g=grad_flat, v=p_flat)
-        p_flat    = velocity_step(p_flat, step_size/2, grad_flat)
+        p_flat    = velocity_step(p_flat, 0.5*step_size, grad_flat)
         # jax.debug.print("post: p_flat={v}", ordered=True, v=p_flat)
 
         # loop full position and velocity leapfrog steps
@@ -163,7 +163,7 @@ def gen_integrator(tempered_potential, initial_state):
         # final full position step plus half velocity step
         x_flat    = position_step(x_flat, step_size, precond_state, p_flat)
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
-        p_flat    = velocity_step(p_flat, step_size/2, grad_flat)
+        p_flat    = velocity_step(p_flat, 0.5*step_size, grad_flat)
         
         # unravel, update state, and return it
         x_new = unravel_fn(x_flat)

--- a/autostep/autohmc.py
+++ b/autostep/autohmc.py
@@ -17,7 +17,7 @@ class AutoHMC(autostep.AutoStep):
         potential_fn=None,
         tempered_potential = None,
         n_leapfrog_steps = 1,
-        init_base_step_size = 1.0,
+        init_base_step_size = 1e-5,
         selector = selectors.SymmetricSelector(),
         preconditioner = preconditioning.FixedDiagonalPreconditioner(),
         init_inv_temp = None

--- a/autostep/autohmc.py
+++ b/autostep/autohmc.py
@@ -40,35 +40,65 @@ class AutoHMC(autostep.AutoStep):
         return initial_state
     
     def update_log_joint(self, state):
-        x, v_flat, *_ = state
+        x, p_flat, *_ = state
         new_temp_pot = self.tempered_potential(x, state.inv_temp)
-        new_log_joint = -new_temp_pot - std_normal_potential(v_flat)
+        new_log_joint = -new_temp_pot - std_normal_potential(p_flat)
         new_stats = statistics.increase_n_pot_evals_by_one(state.stats)
         return state._replace(log_joint = new_log_joint, stats = new_stats)
     
     def refresh_aux_vars(self, state):
         rng_key, v_key = random.split(state.rng_key)
-        v_flat = random.normal(v_key, jnp.shape(state.v_flat))
-        return state._replace(v_flat = v_flat, rng_key = rng_key)
+        p_flat = random.normal(v_key, jnp.shape(state.p_flat))
+        return state._replace(p_flat = p_flat, rng_key = rng_key)
     
-    def involution_main(self, step_size, state, precond_array):
+    def involution_main(self, step_size, state, precond_state):
         return self.integrator(
-            step_size, state, precond_array, self.n_leapfrog_steps
+            step_size, state, precond_state, self.n_leapfrog_steps
         )
     
-    def involution_aux(self, step_size, state, precond_array):
-        return state._replace(v_flat = -state.v_flat)
+    def involution_aux(self, step_size, state, precond_state):
+        return state._replace(p_flat = -state.p_flat)
 
 
-#######################################
+##############################################################################
 # leapfrog (velocity Verlet) integrator
-#######################################
+# The update is
+# 	p* = p  - (eps/2)grad(U)(x)
+# 	x' = x  + eps M^{-1}p*
+# 	p' = p* - (eps/2)grad(U)(x')
+# Let L lower triangular such that
+#   M = LL^T
+# If y ~ N(0,I), then
+#   p = Ly ~ N(0,M)
+# Working in this space requires
+#   - Getting L=chol(M) and M^{-1}= [L^{-1}]^T [L^{-1}]
+#   - At each step we need 3 matrix ops:
+#       1) Sampling p = Ly
+#       2) kinetic energy eval: [L^{-1}p]^T [L^{-1}p]
+#       3) For each leapfrog, a single matop (M^{-1}p)
+# The alternative is to work with y:=L^{-1}p, which gives the updates 
+# 	y* = y  - (eps/2)L^{-1}grad(U)(x)
+# 	x' = x  + eps (L^T)^{-1}y
+# 	y' = y* - (eps/2)L^{-1}grad(U)(x')
+# This means we need 
+#   - To get L^{-1} and (L^{-1})^T
+#   - No matrix ops outside leapfrog
+#   - ...but 3 O(d^2) ops for every LF step!
+# So this is too expensive.
+#
+# Note: when M = S^{-1}, with S=Cov(x). Clearly, M^{-1}=S. But also,
+#   S = LL^T <=> M = S^{-1} = (L^T)^{-1}L^{-1} = UU^T
+# where U := (L^T)^{-1}. This solve is O(d^2) because L^T is upper triangular,
+# which also means that U is also upper triangular. Then we have
+#   p = Uy ~ N(0,M)
+# Hence, we need S (no-op as this is directly estimated) and U.
+##############################################################################
 
-def velocity_step(v_flat, step_size, precond_array, grad_flat):
-    return v_flat - step_size * apply_precond(precond_array, grad_flat)
+def velocity_step(p_flat, step_size, precond_state, grad_flat):
+    return p_flat - step_size * apply_precond(precond_state, grad_flat)
 
-def position_step(x_flat, step_size, precond_array, v_flat):
-    return x_flat + step_size * apply_precond(precond_array, v_flat)
+def position_step(x_flat, step_size, precond_state, p_flat):
+    return x_flat + step_size * apply_precond(precond_state, p_flat)
 
 # helper function to define the leapfrog integrator
 def gen_integrator(tempered_potential, initial_state):
@@ -85,47 +115,48 @@ def gen_integrator(tempered_potential, initial_state):
 
     # full position and velocity updates
     def integrator_scan_body_fn(carry, _):
-        x_flat, v_flat, step_size, precond_array, inv_temp = carry
-        x_flat    = position_step(x_flat, step_size, precond_array, v_flat)
+        x_flat, p_flat, step_size, precond_state, inv_temp = carry
+        x_flat    = position_step(x_flat, step_size, precond_state, p_flat)
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
-        v_flat    = velocity_step(v_flat, step_size, precond_array, grad_flat)
-        return (x_flat, v_flat, step_size, precond_array, inv_temp), None
+        p_flat    = velocity_step(p_flat, step_size, precond_state, grad_flat)
+        return (x_flat, p_flat, step_size, precond_state, inv_temp), None
     
     # leapfrog integrator using Neal (2011, Fig. 2) trick to use only 
     # (n_steps+1) grad evals
-    # IMPORTANT: `precond_array` is on the scale of Sigma^{1/2}, where Sigma=Cov(x)
-    def integrator(step_size, state, precond_array, n_steps):
-        # jax.debug.print("start: step_size={s}, precond_array={d}", ordered=True, s=step_size, d=precond_array)
+    # IMPORTANT: contrary to HMC convention, `precond_state` is on the scale of
+    # Sigma^{1/2}, where Sigma=Cov(x_flat)
+    def integrator(step_size, state, precond_state, n_steps):
+        # jax.debug.print("start: step_size={s}, precond_state={d}", ordered=True, s=step_size, d=precond_state)
 
         # first velocity half-step
-        x, v_flat, *_, inv_temp = state
+        x, p_flat, *_, inv_temp = state
         x_flat    = flatten_util.ravel_pytree(x)[0]
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
-        # jax.debug.print("pre 1st momentum half-step: x={x}, x_flat={xf}, grad={g}, v_flat={v}", ordered=True, x=x, xf=x_flat, g=grad_flat, v=v_flat)
-        v_flat    = velocity_step(v_flat, step_size/2, precond_array, grad_flat)
-        # jax.debug.print("post: v_flat={v}", ordered=True, v=v_flat)
+        # jax.debug.print("pre 1st momentum half-step: x={x}, x_flat={xf}, grad={g}, p_flat={v}", ordered=True, x=x, xf=x_flat, g=grad_flat, v=p_flat)
+        p_flat    = velocity_step(p_flat, step_size/2, precond_state, grad_flat)
+        # jax.debug.print("post: p_flat={v}", ordered=True, v=p_flat)
 
         # loop full position and velocity leapfrog steps
         # note: slight modification from Neal's to avoid the "if" inside the loop
         # In particular, MALA (n_steps=1) doesn't enter the loop
-        x_flat, v_flat, *_ = lax.scan(
+        x_flat, p_flat, *_ = lax.scan(
             integrator_scan_body_fn,
-            (x_flat, v_flat, step_size, precond_array, inv_temp),
+            (x_flat, p_flat, step_size, precond_state, inv_temp),
             None,
             n_steps-1
         )[0]
-        # jax.debug.print("post loop: x_flat={xf}, v_flat={v}", ordered=True, xf=x_flat, v=v_flat)
+        # jax.debug.print("post loop: x_flat={xf}, p_flat={v}", ordered=True, xf=x_flat, v=p_flat)
 
         # final full position step plus half velocity step
-        x_flat    = position_step(x_flat, step_size, precond_array, v_flat)
+        x_flat    = position_step(x_flat, step_size, precond_state, p_flat)
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
-        v_flat    = velocity_step(v_flat, step_size/2, precond_array, grad_flat)
+        p_flat    = velocity_step(p_flat, step_size/2, precond_state, grad_flat)
         
         # unravel, update state, and return it
         x_new = unravel_fn(x_flat)
-        # jax.debug.print("final: x_new={x}, x_flat={xf}, grad={g}, v_flat={v}", ordered=True, x=x_new, xf=x_flat, g=grad_flat, v=v_flat)
+        # jax.debug.print("final: x_new={x}, x_flat={xf}, grad={g}, p_flat={v}", ordered=True, x=x_new, xf=x_flat, g=grad_flat, v=p_flat)
 
-        return state._replace(x = x_new, v_flat = v_flat)
+        return state._replace(x = x_new, p_flat = p_flat)
     
     return integrator
 

--- a/autostep/autorwmh.py
+++ b/autostep/autorwmh.py
@@ -17,7 +17,7 @@ class AutoRWMH(autostep.AutoStep):
         tempered_potential = None,
         init_base_step_size = 1.0,
         selector = selectors.SymmetricSelector(),
-        preconditioner = preconditioning.MixDiagonalPreconditioner(),
+        preconditioner = preconditioning.FixedDiagonalPreconditioner(),
         init_inv_temp = None
     ):
         self._model = model
@@ -31,27 +31,27 @@ class AutoRWMH(autostep.AutoStep):
             None if init_inv_temp is None else jnp.array(init_inv_temp)
         )
 
-    def update_log_joint(self, state):
-        x, v_flat, *_ = state
+    def update_log_joint(self, state, precond_state):
+        x, p_flat, *_ = state
         new_temp_pot = self.tempered_potential(x, state.inv_temp)
-        new_log_joint = -new_temp_pot - utils.std_normal_potential(v_flat)
+        new_log_joint = -new_temp_pot - 0.5*jnp.dot(p_flat, p_flat)
         new_stats = statistics.increase_n_pot_evals_by_one(state.stats)
         return state._replace(log_joint = new_log_joint, stats = new_stats)
     
-    def refresh_aux_vars(self, state):
+    def refresh_aux_vars(self, state, precond_state):
         rng_key, v_key = random.split(state.rng_key)
-        v_flat = random.normal(v_key, jnp.shape(state.v_flat))
-        return state._replace(v_flat = v_flat, rng_key = rng_key)
+        p_flat = random.normal(v_key, jnp.shape(state.p_flat))
+        return state._replace(p_flat = p_flat, rng_key = rng_key)
     
     def involution_main(self, step_size, state, precond_state):
         x_flat, unravel_fn = flatten_util.ravel_pytree(state.x)
         if jnp.ndim(precond_state.var_chol_tril) == 2:
-            prec_v_flat = precond_state.var_chol_tril @ state.v_flat
+            prec_p_flat = precond_state.var_chol_tril @ state.p_flat
         else:
-            prec_v_flat = precond_state.var_chol_tril * state.v_flat
-        x_new = unravel_fn(x_flat + step_size * prec_v_flat)
+            prec_p_flat = precond_state.var_chol_tril * state.p_flat
+        x_new = unravel_fn(x_flat + step_size * prec_p_flat)
         return state._replace(x = x_new)
     
     def involution_aux(self, step_size, state, precond_state):
-        return state._replace(v_flat = -state.v_flat)
+        return state._replace(p_flat = -state.p_flat)
 

--- a/autostep/autostep.py
+++ b/autostep/autostep.py
@@ -357,7 +357,7 @@ class AutoStep(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
                 round <= self.adapt_rounds,              # are we still adapting?
                 stats.adapt_stats.sample_idx == 2**round # are we at the end of a round?
             ),
-            partial(statistics.update_sampler_params, self.preconditioner),
+            statistics.update_sampler_params,
             util.identity,
             (state.base_step_size, state.base_precond_state, stats.adapt_stats)
         )
@@ -372,9 +372,9 @@ class AutoStep(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         #     n_samples={n}, round={r}, sample_idx={s},
         #     base_step_size={b}, base_precond_state={e},
         #     mean_step_size={ms}, mean_acc_prob={ma},
-        #     means_flat={m}, vars_flat={v}""", ordered=True,
+        #     sample_mean={m}, sample_var={v}""", ordered=True,
         #     n=stats.n_samples,r=round,s=stats.adapt_stats.sample_idx,
         #     b=state.base_step_size, e=state.base_precond_state,
         #     ms=new_stats.adapt_stats.mean_step_size, ma=new_stats.adapt_stats.mean_acc_prob,
-        #     m=new_stats.adapt_stats.means_flat,v=new_stats.adapt_stats.vars_flat)
+        #     m=new_stats.adapt_stats.sample_mean,v=new_stats.adapt_stats.sample_var)
         return state

--- a/autostep/autostep.py
+++ b/autostep/autostep.py
@@ -209,6 +209,13 @@ class AutoStep(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         precond_state = self.preconditioner.maybe_alter_precond_state(
             state.base_precond_state, precond_key
         )
+        # jax.debug.print(
+        #     "precond_state: var={v}   chol_tril={c}   inv_fac={i}", 
+        #     ordered=True, 
+        #     v=precond_state.var,
+        #     c=precond_state.var_chol_tril,
+        #     i=precond_state.inv_var_triu_factor
+        # )
 
         # refresh auxiliary variables (e.g., momentum), update the log joint 
         # density, and finally check if the latter is finite

--- a/autostep/preconditioning.py
+++ b/autostep/preconditioning.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from collections import namedtuple
+
 import jax
 from jax import lax
 from jax import numpy as jnp
@@ -7,43 +9,52 @@ from jax import random
 
 from numpyro import util
 
+###############################################################################
+# type definitions
+###############################################################################
+
 class Preconditioner(ABC):
 
     @staticmethod
     @abstractmethod
-    def build_precond(sqrt_var, rng_key):
+    def maybe_alter_precond_state(precond_state, rng_key):
         """
         Build a (possible randomized) preconditioner.
 
-        :param sqrt_var: An array representing the square-root of a covariance matrix.
+        :param precond_state: An array representing the square-root of a covariance matrix.
             It can be a matrix---for dense preconditioners---or a vector---for
             the diagonal case.
         :param rng_key: A PRNG key that could be used for random preconditioning.
         :return: A vector representing a diagonal preconditioner.
         """
         raise NotImplementedError
-    
+
+#######################################
+# Diagonal
+#######################################
+
 class IdentityDiagonalPreconditioner(Preconditioner):
 
     @staticmethod
-    def build_precond(sqrt_var, rng_key):
-        return jnp.ones_like(sqrt_var)
+    def maybe_alter_precond_state(precond_state, rng_key):
+        return jnp.ones_like(precond_state)
 
 class FixedDiagonalPreconditioner(Preconditioner):
 
     @staticmethod
-    def build_precond(sqrt_var, rng_key):
-        return sqrt_var
+    def maybe_alter_precond_state(precond_state, rng_key):
+        return precond_state
 
-class MixDiagonalPreconditioner(Preconditioner):
+# class MixDiagonalPreconditioner(Preconditioner):
 
-    @staticmethod
-    def build_precond(sqrt_var, rng_key):
-        assert jnp.ndim(sqrt_var) == 1
+#     @staticmethod
+#     def maybe_alter_precond_state(precond_state, rng_key):
+#         raise(NotImplementedError("TODO: IMPLEMENT CORRECTLY"))
+#         assert jnp.ndim(precond_state) == 1
 
-        # uniform mixture in log space
-        # p = exp(U*log(hat_sd) + (1-U)log(1)) = exp(log(hat_sd^U))) = hat_sd^U
-        return sqrt_var ** random.uniform(rng_key)
+#         # uniform mixture in log space
+#         # p = exp(U*log(hat_sd) + (1-U)log(1)) = exp(log(hat_sd^U))) = hat_sd^U
+#         return precond_state ** random.uniform(rng_key)
 
 #######################################
 # Dense
@@ -52,25 +63,105 @@ class MixDiagonalPreconditioner(Preconditioner):
 class FixedDensePreconditioner(Preconditioner):
 
     @staticmethod
-    def build_precond(sqrt_var, rng_key):
-        return sqrt_var
-
-class MixDensePreconditioner(Preconditioner):
-
-    @staticmethod
-    def build_precond(sqrt_var, rng_key):
-        assert jnp.ndim(sqrt_var) == 2
-
-        # with equal prob choose the estimate or the identity
-        return lax.cond(
-            random.bernoulli(rng_key),
-            util.identity,
-            lambda M: jnp.eye(*M.shape),
-            sqrt_var
-        )
+    def maybe_alter_precond_state(precond_state, rng_key):
+        return precond_state
 
 def is_dense(preconditioner):
     return (
-        isinstance(preconditioner, FixedDensePreconditioner) or
-        isinstance(preconditioner, MixDensePreconditioner)
+        isinstance(preconditioner, FixedDensePreconditioner)
     )
+
+###############################################################################
+# Preconditioner state
+# 
+# The most demanding application is for dense preconditioners. To handle both
+# AutoRWMH and AutoHMC. Let S = Cov(x), M = S^{-1}, an y~N(0,I). We need,
+#   - S, for
+#       - AutoHMC: kinetic energy 0.5p^TM^{-1}p = 0.5*jnp.dot(S@p,p)
+#       - AutoHMC: LF postition update x' = x + eps M^{-1}p = x + eps Sp
+#   - L = chol(S), for 
+#       - AutoRWMH: proposal x' = x + epsLy
+#   - A factorization of the form M = UU^T for
+#       - AutoHMC: sample momentum p = Uy ~ N(0,M)
+# 
+# The last decomposition can be gotten by manipulating a Cholesky factorization
+# of S, since
+#     S = LL^T <=> M = S^{-1} = (L^T)^{-1}L^{-1} = UU^T  
+# This approach---an O(d^3) chol followed by an O(d^2) triangular solve---is 
+# much more efficient than doing 2 O(d^3) ops in chol(inv(S)). We don't need
+# U to be lower triangular or even triangular. Any decomposition M=UU^T works. 
+#
+# An example to check that this works:
+# 
+# # sample a symmetric mat (a.s. posdef) to use as variance
+# var_key, sim_key = random.split(random.key(2176543))
+# N = random.normal(var_key, (2,2))
+# S = N.T @ N
+
+# # chol of variance mat
+# L = jax.lax.linalg.cholesky(S)
+# jnp.allclose(S, L @ L.T)
+
+# # decompose M = S^{-1} = UU^T by doing a triangular solve of L^{T}
+# U = jax.lax.linalg.triangular_solve(L.T, jnp.identity(2))
+# M = jnp.linalg.inv(S)
+# jnp.allclose(M, U @ U.T)
+
+# # check that p=Uy ~ N(0,M) when y ~ N(0,I)
+# ps = jax.vmap(
+#     lambda rng_key: U @ random.normal(rng_key, (2,)),
+#     out_axes=1
+# )(random.split(sim_key, 10000))
+# jnp.allclose(M, jnp.cov(ps), rtol=0.05)
+###############################################################################
+
+PreconditionerState = namedtuple(
+    "PreconditionerState",
+    [
+        "var",
+        "var_chol_tril",
+        "inv_var_triu_factor"
+    ]
+)
+"""
+A :func:`~collections.namedtuple` defining the values associated with a 
+preconditioner. It consists of the fields:
+
+ - **var** - Estimated and regularized target variance.
+ - **var_chol_tril** - Cholesky tril factor of `var`.
+ - **inv_var_triu_factor** - A triu matrix `U` such that `inv(var)=U @ U.T`
+"""
+
+# initialization
+def init_base_precond_state(sample_field_flat_shape, preconditioner):
+    if is_dense(preconditioner):
+        return PreconditionerState(
+            jnp.identity(sample_field_flat_shape),
+            jnp.identity(sample_field_flat_shape),
+            jnp.identity(sample_field_flat_shape)
+        )
+    else: 
+        return PreconditionerState(
+            jnp.ones(sample_field_flat_shape),
+            jnp.ones(sample_field_flat_shape),
+            jnp.ones(sample_field_flat_shape)
+        )
+
+# adapt the base preconditioner state, regularizing to avoid issues with 
+# ill-conditioned sample variances
+# note: this is apparently the approach used in Stan, according to NumPyro
+# https://github.com/pyro-ppl/numpyro/blob/ab1f0dc6e954ef7d54724386667e33010b2cfc8b/numpyro/infer/hmc_util.py#L219
+def adapt_base_precond_state(preconditioner, vars_flat, n):
+    scaled_var = (n / (n + 5)) * vars_flat
+    eps = 1e-3 * (5 / (n + 5))
+    if is_dense(preconditioner):
+        I = jnp.identity(scaled_var.shape[0])
+        var_chol_tril = lax.linalg.cholesky(scaled_var + eps*I)
+        inv_var_triu_factor = jax.lax.linalg.triangular_solve(
+            var_chol_tril.T, I
+        )
+    else:
+        var_chol_tril = lax.sqrt(scaled_var + eps)
+        inv_var_triu_factor = jnp.reciprocal(var_chol_tril)
+
+    return PreconditionerState(scaled_var, var_chol_tril, inv_var_triu_factor)

--- a/autostep/preconditioning.py
+++ b/autostep/preconditioning.py
@@ -147,12 +147,14 @@ def adapt_base_precond_state(sample_var, n):
     eps = 1e-3 * (5 / (n + 5))
     if jnp.ndim(sample_var) == 2:
         I = jnp.identity(scaled_var.shape[0])
-        var_chol_tril = lax.linalg.cholesky(scaled_var + eps*I)
+        var = scaled_var + eps*I
+        var_chol_tril = lax.linalg.cholesky(var)
         inv_var_triu_factor = jax.lax.linalg.triangular_solve(
             var_chol_tril.T, I
         )
     else:
-        var_chol_tril = lax.sqrt(scaled_var + eps)
+        var = scaled_var + eps
+        var_chol_tril = lax.sqrt(var)
         inv_var_triu_factor = jnp.reciprocal(var_chol_tril)
 
-    return PreconditionerState(scaled_var, var_chol_tril, inv_var_triu_factor)
+    return PreconditionerState(var, var_chol_tril, inv_var_triu_factor)

--- a/autostep/statistics.py
+++ b/autostep/statistics.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from jax import lax
 from jax import numpy as jnp
 
-from autostep.preconditioning import is_dense
+from autostep.preconditioning import is_dense, adapt_base_precond_state
 
 AutoStepAdaptStats = namedtuple(
     "AutoStepAdaptStats",
@@ -124,20 +124,11 @@ def update_sampler_params(preconditioner, args):
     # set the average step size of the prev round as the new base step size
     new_base_step_size = adapt_stats.mean_step_size
 
-    # adapt the sqrt_var array, regularizing to avoid issues with 
-    # ill-conditioned sample variances
-    # note: this is apparently the approach used in Stan, according to NumPyro
-    # https://github.com/pyro-ppl/numpyro/blob/ab1f0dc6e954ef7d54724386667e33010b2cfc8b/numpyro/infer/hmc_util.py#L219
-    n = adapt_stats.sample_idx
-    scaled_vars_flat = (n / (n + 5)) * adapt_stats.vars_flat
-    eps = 1e-3 * (5 / (n + 5))
-    if is_dense(preconditioner):
-        new_sqrt_var = lax.linalg.cholesky(
-            scaled_vars_flat + eps*jnp.identity(scaled_vars_flat.shape[0])
-        )
-    else:
-        new_sqrt_var = lax.sqrt(scaled_vars_flat + eps)
+    # adapt the preconditioner
+    new_precond_state = adapt_base_precond_state(
+        preconditioner, adapt_stats.vars_flat, adapt_stats.sample_idx
+    )
 
     # empty the adapt recorder and return
     new_adapt_stats = empty_adapt_stats_recorder(adapt_stats)
-    return (new_base_step_size, new_sqrt_var, new_adapt_stats)
+    return (new_base_step_size, new_precond_state, new_adapt_stats)

--- a/autostep/utils.py
+++ b/autostep/utils.py
@@ -32,11 +32,11 @@ def ceil_log2(x):
     n_bits = jax.lax.clz(jnp.zeros_like(x))
     return n_bits - jax.lax.clz(x) - (jax.lax.population_count(x)==1)
 
-def apply_precond(precond_array, vec):
+def apply_precond(precond_state, vec):
     return (
-        precond_array * vec 
-        if jnp.ndim(precond_array) == 1 
-        else precond_array @ vec
+        precond_state * vec 
+        if jnp.ndim(precond_state) == 1 
+        else precond_state @ vec
     )
 
 def numerically_safe_diff(x0, x1):
@@ -99,12 +99,6 @@ def init_model(model, rng_key, model_args, model_kwargs):
     potential_fn = potential_fn_gen(*model_args, **model_kwargs)
     return init_params, potential_fn, postprocess_fn
 
-def init_sqrt_var(sample_field_flat_shape, preconditioner):
-    if is_dense(preconditioner):
-        return jnp.eye(*(2*sample_field_flat_shape))
-    else: 
-        return jnp.ones(sample_field_flat_shape)
-
 ###############################################################################
 # functions used withing lax.cond to create the output state for `sample`
 ###############################################################################
@@ -139,7 +133,7 @@ def gen_alter_step_size_cond_fun(pred_fun, max_n_iter):
             next_log_joint, 
             init_log_joint,
             selector_params, 
-            precond_array
+            precond_state
         ) = args
 
         # `numerically_safe_diff` is used to avoid corner cases where the step
@@ -163,12 +157,12 @@ def gen_alter_step_size_body_fun(kernel, direction):
             next_log_joint, 
             init_log_joint,
             selector_params, 
-            precond_array
+            precond_state
         ) = args
         exponent = exponent + direction
         eps = step_size(state.base_step_size, exponent)
         next_state = kernel.update_log_joint(
-            kernel.involution_main(eps, state, precond_array)
+            kernel.involution_main(eps, state, precond_state)
         )
         next_log_joint = next_state.log_joint
         state = copy_state_extras(next_state, state)
@@ -195,7 +189,7 @@ def gen_alter_step_size_body_fun(kernel, direction):
             next_log_joint, 
             init_log_joint,
             selector_params, 
-            precond_array
+            precond_state
         )
 
     return alter_step_size_body_fun

--- a/autostep/utils.py
+++ b/autostep/utils.py
@@ -22,9 +22,6 @@ def proto_checkified_is_zero(x):
 
 checkified_is_zero = checkify.checkify(proto_checkified_is_zero)
 
-def std_normal_potential(v):
-    return (v*v).sum()/2
-
 def ceil_log2(x):
     """
     Ceiling of log2(x). Guaranteed to be an integer.
@@ -162,7 +159,8 @@ def gen_alter_step_size_body_fun(kernel, direction):
         exponent = exponent + direction
         eps = step_size(state.base_step_size, exponent)
         next_state = kernel.update_log_joint(
-            kernel.involution_main(eps, state, precond_state)
+            kernel.involution_main(eps, state, precond_state),
+            precond_state
         )
         next_log_joint = next_state.log_joint
         state = copy_state_extras(next_state, state)

--- a/tests/test_Kernels.py
+++ b/tests/test_Kernels.py
@@ -11,37 +11,77 @@ from numpyro.infer import MCMC
 
 from autostep import autohmc
 from autostep import autorwmh
+from autostep import preconditioning
 from autostep import selectors
+from autostep import statistics
 from autostep import utils
 
+def rand_sample_var(rng_key, var_shape):
+    N = random.normal(rng_key, var_shape)
+    if len(var_shape) == 2:
+        return N.T @ N
+    else:
+        return N * N
 
 class TestKernels(unittest.TestCase):
 
     TESTED_KERNELS = (
         autorwmh.AutoRWMH,
         autohmc.AutoMALA,
-        partial(autohmc.AutoHMC, n_leapfrog_steps=10)
+        partial(autohmc.AutoHMC, n_leapfrog_steps=128)
+    )
+
+    TESTED_PRECONDITIONERS = (
+        preconditioning.IdentityDiagonalPreconditioner(),
+        preconditioning.FixedDiagonalPreconditioner(),
+        preconditioning.FixedDensePreconditioner()
     )
     
     def test_involution(self):
         d = 4
         rng_key = random.key(321)
-        for i in range(10):
-            for kernel_class in self.TESTED_KERNELS:
-                with self.subTest(kernel_class=kernel_class, i=i):
-                    rng_key, x_key, v_key, prec_key, step_key = random.split(rng_key, 5) 
-                    r = kernel_class(potential_fn=testutils.gaussian_potential)
-                    s = r.init(rng_key, 0, random.normal(x_key, d), (), ())
-                    s = s._replace(
-                        p_flat = random.normal(v_key, d),
-                        base_step_size = random.exponential(step_key))
-                    diag_precond = 0.1 * random.exponential(prec_key, d)
-                    step_size = utils.step_size(s.base_step_size, -1)
-                    s_half = r.involution_main(step_size, s, diag_precond)
-                    s_one = r.involution_aux(step_size, s_half, diag_precond)
-                    s_onehalf = r.involution_main(step_size, s_one, diag_precond)
-                    s_two = r.involution_aux(step_size, s_onehalf, diag_precond)
-                    self.assertTrue(jax.tree.all(jax.tree.map(partial(jnp.allclose, atol=1e-4), s_two, s)))
+        for prec in self.TESTED_PRECONDITIONERS:
+            for i in range(10):
+                rng_key, x_key, v_key, var_key, prec_key, step_key = random.split(rng_key, 6)
+                init_x = random.normal(x_key, d)
+                init_p_flat = random.normal(v_key, d)
+                var_shape = (d,d) if preconditioning.is_dense(prec) else (d,)
+                adapt_stats = statistics.AutoStepAdaptStats(
+                    100000,
+                    0.1 * random.exponential(step_key), 
+                    0., 
+                    jnp.zeros_like(init_x),
+                    rand_sample_var(var_key, var_shape)
+                )
+                for kernel_class in self.TESTED_KERNELS:
+                    with self.subTest(prec=prec, i=i, kernel_class=kernel_class):
+                        r = kernel_class(
+                            potential_fn=testutils.gaussian_potential,
+                            preconditioner = prec
+                        )
+                        # rng_key is not used because we are passing initial parameters
+                        s = r.init(rng_key, 0, init_x, (), ()) 
+                        s = s._replace(
+                            p_flat = init_p_flat, 
+                            stats=s.stats._replace(adapt_stats=adapt_stats)
+                        )
+                        s = r.adapt(s, True) # populates base_precond_state and base_step_size
+                        precond_state = prec.maybe_alter_precond_state(
+                            s.base_precond_state, prec_key
+                        )
+                        step_size = utils.step_size(s.base_step_size, 0)
+                        s_half = r.involution_main(step_size, s, precond_state)
+                        s_one = r.involution_aux(step_size, s_half, precond_state)
+                        s_onehalf = r.involution_main(step_size, s_one, precond_state)
+                        s_two = r.involution_aux(step_size, s_onehalf, precond_state)
+                        self.assertTrue(
+                            jnp.allclose(s_two.x, s.x, rtol=1e-3),
+                            msg=f"s.x={s.x} but s_two.x={s_two.x}"
+                        )
+                        self.assertTrue(
+                            jnp.allclose(s_two.p_flat, s.p_flat, rtol=1e-3),
+                            msg=f"s.p_flat={s.p_flat} but s_two.p_flat={s_two.p_flat}"
+                        )
 
     def test_moments(self):
 
@@ -72,8 +112,8 @@ class TestKernels(unittest.TestCase):
                     self.assertEqual(adapt_stats.sample_idx, n_keep)
                     self.assertEqual(n_keep, jnp.shape(mcmc.get_samples())[0])
                     self.assertTrue(jnp.allclose(state.var_chol_tril, jnp.sqrt(true_var), atol=tol, rtol=tol))
-                    self.assertTrue(jnp.allclose(adapt_stats.means_flat, true_mean, atol=tol, rtol=tol))
-                    self.assertTrue(jnp.allclose(adapt_stats.vars_flat, true_var, atol=tol, rtol=tol))
+                    self.assertTrue(jnp.allclose(adapt_stats.sample_mean, true_mean, atol=tol, rtol=tol))
+                    self.assertTrue(jnp.allclose(adapt_stats.sample_var, true_var, atol=tol, rtol=tol))
 
     def test_numpyro_model(self):
         n_rounds = 10

--- a/tests/test_Kernels.py
+++ b/tests/test_Kernels.py
@@ -71,7 +71,7 @@ class TestKernels(unittest.TestCase):
                     self.assertEqual(stats.n_samples, n_warmup+n_keep)
                     self.assertEqual(adapt_stats.sample_idx, n_keep)
                     self.assertEqual(n_keep, jnp.shape(mcmc.get_samples())[0])
-                    self.assertTrue(jnp.allclose(state.sqrt_var, jnp.sqrt(true_var), atol=tol, rtol=tol))
+                    self.assertTrue(jnp.allclose(state.var_chol_tril, jnp.sqrt(true_var), atol=tol, rtol=tol))
                     self.assertTrue(jnp.allclose(adapt_stats.means_flat, true_mean, atol=tol, rtol=tol))
                     self.assertTrue(jnp.allclose(adapt_stats.vars_flat, true_var, atol=tol, rtol=tol))
 

--- a/tests/test_Kernels.py
+++ b/tests/test_Kernels.py
@@ -33,7 +33,7 @@ class TestKernels(unittest.TestCase):
                     r = kernel_class(potential_fn=testutils.gaussian_potential)
                     s = r.init(rng_key, 0, random.normal(x_key, d), (), ())
                     s = s._replace(
-                        v_flat = random.normal(v_key, d),
+                        p_flat = random.normal(v_key, d),
                         base_step_size = random.exponential(step_key))
                     diag_precond = 0.1 * random.exponential(prec_key, d)
                     step_size = utils.step_size(s.base_step_size, -1)

--- a/tests/test_preconditioning.py
+++ b/tests/test_preconditioning.py
@@ -16,11 +16,12 @@ class TestPreconditioning(unittest.TestCase):
     def test_preconditioning(self):
         dim = 3
         rho = 0.9
-        tol = 0.1
+        tol = 0.15
+        n_rounds = 14
+
         init_vals = jnp.ones(dim)
         S = testutils.make_const_off_diag_corr_mat(dim, rho)
         pot_fn = testutils.make_correlated_Gaussian_potential(S)
-        n_rounds = 14
         n_warmup, n_keep = utils.split_n_rounds(n_rounds) # translate rounds to warmup/keep
         precs = (
             preconditioning.IdentityDiagonalPreconditioner(),

--- a/tests/test_preconditioning.py
+++ b/tests/test_preconditioning.py
@@ -36,12 +36,12 @@ class TestPreconditioning(unittest.TestCase):
                 self.assertGreater(min_ess, 77) # >200 locally but on CI-macos-latest FixedDense fails (~77)
                 last_round_used_var = mcmc.last_state.base_precond_state.var
                 if preconditioning.is_dense(p):
-                    last_round_estimate_var = mcmc.last_state.stats.adapt_stats.vars_flat
+                    last_round_estimate_var = mcmc.last_state.stats.adapt_stats.sample_var
                     self.assertTrue(jnp.allclose(S, last_round_used_var, atol=0.25))
                     self.assertTrue(jnp.allclose(S, last_round_estimate_var, atol=0.15))
                 else:
                     diag_S = jnp.diag(S)
-                    last_round_estimate_var = mcmc.last_state.stats.adapt_stats.vars_flat
+                    last_round_estimate_var = mcmc.last_state.stats.adapt_stats.sample_var
                     self.assertTrue(jnp.allclose(diag_S, last_round_estimate_var, atol=0.15))
                     if not isinstance(p, preconditioning.IdentityDiagonalPreconditioner):
                         self.assertTrue(jnp.allclose(diag_S, last_round_used_var, atol=0.15))

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -16,29 +16,43 @@ class TestSelectors(unittest.TestCase):
         asym_sel = selectors.AsymmetricSelector()
         sym_sel = selectors.SymmetricSelector()
         fix_sel = selectors.FixedStepSizeSelector()
+        det_asym_sel = selectors.DeterministicAsymmetricSelector()
+        det_sym_sel = selectors.DeterministicSymmetricSelector()
         params = jnp.array([-1.5, -0.5])
 
         # sym and asym should give different decisions here
         log_diff = jnp.float32(0.8)
         self.assertTrue(asym_sel.should_grow(params, log_diff))
+        self.assertTrue(det_asym_sel.should_grow(params, log_diff))
         self.assertFalse(sym_sel.should_grow(params, log_diff))
+        self.assertFalse(det_sym_sel.should_grow(params, log_diff))
         self.assertFalse(fix_sel.should_grow(params, log_diff))
         self.assertFalse(asym_sel.should_shrink(params, log_diff))
+        self.assertFalse(det_asym_sel.should_shrink(params, log_diff))
         self.assertFalse(sym_sel.should_shrink(params, log_diff))
+        self.assertFalse(det_sym_sel.should_shrink(params, log_diff))
         self.assertFalse(fix_sel.should_shrink(params, log_diff))
 
         # sym and asym should agree in the following 2 cases
         log_diff = jnp.float32(-2)
         self.assertFalse(asym_sel.should_grow(params, log_diff))
+        self.assertFalse(det_asym_sel.should_grow(params, log_diff))
         self.assertFalse(sym_sel.should_grow(params, log_diff))
+        self.assertFalse(det_sym_sel.should_grow(params, log_diff))
         self.assertTrue(asym_sel.should_shrink(params, log_diff))
+        self.assertTrue(det_asym_sel.should_shrink(params, log_diff))
         self.assertTrue(sym_sel.should_shrink(params, log_diff))
+        self.assertTrue(det_sym_sel.should_shrink(params, log_diff))
 
         log_diff = jnp.float32(0)
         self.assertTrue(asym_sel.should_grow(params, log_diff))
+        self.assertTrue(det_asym_sel.should_grow(params, log_diff))
         self.assertTrue(sym_sel.should_grow(params, log_diff))
+        self.assertTrue(det_sym_sel.should_grow(params, log_diff))
         self.assertFalse(asym_sel.should_shrink(params, log_diff))
+        self.assertFalse(det_asym_sel.should_shrink(params, log_diff))
         self.assertFalse(sym_sel.should_shrink(params, log_diff))
+        self.assertFalse(det_sym_sel.should_shrink(params, log_diff))
 
     # fixed selector preserves the initial base step size
     def test_fixed_step_size_preserved(self):

--- a/tests/test_tempering.py
+++ b/tests/test_tempering.py
@@ -40,10 +40,10 @@ class TestTempering(unittest.TestCase):
                     mcmc.run(mcmc_key, *model_args, **model_kwargs)
                     adapt_stats=mcmc.last_state.stats.adapt_stats
                     self.assertTrue(
-                        jnp.allclose(adapt_stats.means_flat, true_mean, atol=0.3, rtol=0.1) # need atol to handle mean=0 for inv_temp=0
+                        jnp.allclose(adapt_stats.sample_mean, true_mean, atol=0.3, rtol=0.1) # need atol to handle mean=0 for inv_temp=0
                     )
                     self.assertTrue(
-                        jnp.allclose(adapt_stats.vars_flat, true_var, rtol=0.25)
+                        jnp.allclose(adapt_stats.sample_var, true_var, rtol=0.25)
                     )
 
 if __name__ == '__main__':

--- a/tests/test_tempering.py
+++ b/tests/test_tempering.py
@@ -1,3 +1,4 @@
+from functools import partial
 from tests import utils as testutils
 
 import unittest
@@ -17,10 +18,11 @@ class TestTempering(unittest.TestCase):
     TESTED_KERNELS = (
         autorwmh.AutoRWMH,
         autohmc.AutoMALA,
+        partial(autohmc.AutoHMC, n_leapfrog_steps=32)
     )
     
     def test_tempered_moments(self):
-        n_rounds = 13
+        n_rounds = 14
         n_warmup, n_keep = utils.split_n_rounds(n_rounds) # translate rounds to warmup/keep
         model, model_args, model_kwargs = testutils.toy_conjugate_normal()
         rng_key = random.key(321453)
@@ -43,7 +45,7 @@ class TestTempering(unittest.TestCase):
                         jnp.allclose(adapt_stats.sample_mean, true_mean, atol=0.3, rtol=0.1) # need atol to handle mean=0 for inv_temp=0
                     )
                     self.assertTrue(
-                        jnp.allclose(adapt_stats.sample_var, true_var, rtol=0.25)
+                        jnp.allclose(adapt_stats.sample_var, true_var, rtol=0.15)
                     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Biggest benefit is to be able to work directly with momentum in HMC so that only 1 matmul is needed per leapfrog step and not 3.