### PR TITLE
add lbfgs as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # `autostep`
 
-***A NumPyro-compatible JAX implementation of autoStep methods***
+***A NumPyro-compatible JAX implementation of autoStep samplers***
 
 ## Installation
 

--- a/autostep/autorwmh.py
+++ b/autostep/autorwmh.py
@@ -7,29 +7,6 @@ from autostep import preconditioning
 from autostep import selectors
 
 class AutoRWMH(autostep.AutoStep):
-
-    def __init__(
-        self,
-        model=None,
-        potential_fn=None,
-        logprior_and_loglik = None,
-        init_base_step_size = 1.0,
-        selector = selectors.SymmetricSelector(),
-        preconditioner = preconditioning.FixedDiagonalPreconditioner(),
-        init_inv_temp = None,
-        n_iter_opt_init_params = 0
-    ):
-        self._model = model
-        self._potential_fn = potential_fn
-        self.logprior_and_loglik = logprior_and_loglik
-        self._postprocess_fn = None
-        self.init_base_step_size = init_base_step_size
-        self.selector = selector
-        self.preconditioner = preconditioner
-        self.init_inv_temp = (
-            None if init_inv_temp is None else jnp.array(init_inv_temp)
-        )
-        self.n_iter_opt_init_params = n_iter_opt_init_params
    
     def refresh_aux_vars(self, state, precond_state):
         rng_key, v_key = random.split(state.rng_key)

--- a/autostep/initialization.py
+++ b/autostep/initialization.py
@@ -9,7 +9,8 @@ import optax
 
 from autostep import tempering
 
-# initialize state, potential fun, and postprocess fun for a model
+# initialize a NumPyro model
+# get starting point, potential fun, and postprocess fun
 # Taken without much changes from
 # https://github.com/pyro-ppl/numpyro/blob/master/numpyro/infer/barker.py
 def init_model(model, rng_key, model_args, model_kwargs):
@@ -30,31 +31,87 @@ def init_model(model, rng_key, model_args, model_kwargs):
     potential_fn = potential_fn_gen(*model_args, **model_kwargs)
     return init_params, potential_fn, postprocess_fn
 
+###############################################################################
 # find a better starting point using optimization
-def optimize_init_params(logprior_and_loglik, init_params, inv_temp, n_iter):
-    print(f'Running {n_iter} ADAM iterations to improve initial state.')
+###############################################################################
 
-    # define target function to minimize
+def optimize_init_params(
+        logprior_and_loglik, 
+        init_params, 
+        inv_temp, 
+        initialization_settings
+    ):
+    # define tempered posterior as target function
     target_fun = partial(
         tempering.tempered_potential,
         logprior_and_loglik,
         inv_temp=inv_temp
     )
 
-    # use ADAM to search for better initial point
-    solver = optax.adam(learning_rate=0.003)
+    # select solver
+    if initialization_settings['strategy'] == "L-BFGS":
+        solver, scan_fn = make_lbfgs_solver(target_fun)
+    elif initialization_settings['strategy'] == "ADAM":
+        solver, scan_fn = make_adam_solver(target_fun)
+    else:
+        raise ValueError(
+            f"Unknown strategy '{initialization_settings['strategy']}'"
+        )
+
+    # can reuse stuff because target is deterministic
+    # see https://optax.readthedocs.io/en/stable/api/optimizers.html#lbfgs
+    cached_value_and_grad = optax.value_and_grad_from_state(target_fun)
+
+    # use L-BFGS to search for better initial point
+    solver = optax.lbfgs()
     def scan_fn(carry, _):
         params, opt_state = carry
-        grad = jax.grad(target_fun)(params)
-        updates, opt_state = solver.update(grad, opt_state, params)
+        value, grad = cached_value_and_grad(params, state=opt_state)
+        updates, opt_state = solver.update(
+            grad, opt_state, params, value=value, grad=grad, value_fn=target_fun
+        )
         params = optax.apply_updates(params, updates)
         return (params, opt_state), None
     print(f'Initial energy: {target_fun(init_params):.1e}')
     opt_params, opt_state = lax.scan(
         scan_fn, 
         (init_params, solver.init(init_params)),
-        length = n_iter
+        length = initialization_settings['params']['n_iter']
     )[0]
     print(f'Final energy: {target_fun(opt_params):.1e}')
     
     return opt_params
+
+# L-BFGS
+def make_lbfgs_solver(target_fun):
+    print(f'Using L-BFGS to improve initial state.')
+
+    # can reuse stuff because target is deterministic
+    # see https://optax.readthedocs.io/en/stable/api/optimizers.html#lbfgs
+    cached_value_and_grad = optax.value_and_grad_from_state(target_fun)
+
+    # build solver and loop function
+    solver = optax.lbfgs()
+    def scan_fn(carry, _):
+        params, opt_state = carry
+        value, grad = cached_value_and_grad(params, state=opt_state)
+        updates, opt_state = solver.update(
+            grad, opt_state, params, value=value, grad=grad, value_fn=target_fun
+        )
+        params = optax.apply_updates(params, updates)
+        return (params, opt_state), None
+    
+    return solver, scan_fn
+
+# ADAM
+def make_adam_solver(target_fun):
+    print(f'Using ADAM to improve initial state.')
+    solver = optax.adam(learning_rate=0.003) # LR is from the example in docs
+    def scan_fn(carry, _):
+        params, opt_state = carry
+        grad = jax.grad(target_fun)(params)
+        updates, opt_state = solver.update(grad, opt_state, params)
+        params = optax.apply_updates(params, updates)
+        return (params, opt_state), None
+    
+    return solver, scan_fn


### PR DESCRIPTION
Works great on mRNA and unid, but not on more complicated models. For example, it may get stuck in NaN. So instead of keeping it as only optimizer, I added an `initialization_settings` parameter where users can choose which one to use (along with other parameters).

Also used this PR to move common arguments to the kernels to autostep. Which I previously thought wasn't possible because it is an ABC but it works; see [here](https://stackoverflow.com/q/72924810/5443023). 