### PR TITLE
constrained samplers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  
+
   test:
     strategy:
       fail-fast: true
@@ -28,7 +28,7 @@ jobs:
           pip install coverage .
       - name: Run tests
         run: |
-          python -m coverage run -m unittest
+          python -m coverage run -m unittest -v -f
           python -m coverage xml
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/automcmc/automcmc.py
+++ b/automcmc/automcmc.py
@@ -41,7 +41,7 @@ It consists of the fields:
  - **x** - the sample field, corresponding to a pytree representing a value in
    unconstrained space.
  - **p_flat** - flattened momentum/velocity vector.
- - **log_prior** - log-prior density of ``x``. Includes possible log-abs-det-jac 
+ - **log_prior** - log-prior density of ``x``. Includes possible log-abs-det-jac
    values associated with transformations to unconstrained space.
  - **log_lik** - log-likelihood of ``x``.
  - **log_joint** - log-prior plus log-likelihood plus log density of ``p_flat``.
@@ -49,7 +49,7 @@ It consists of the fields:
  - **stats** - an ``AutoStepStats`` object.
  - **base_step_size** - the initial step size. Fixed within a round but updated
    at the end of it.
- - **base_precond_state** - an instance of ``PreconditionerState``. Fixed within a 
+ - **base_precond_state** - an instance of ``PreconditionerState``. Fixed within a
    round but updated at the end of it.
  - **inv_temp**: optional inverse temperature parameter to target an annealed
    version of a model's distribution.
@@ -60,7 +60,7 @@ It consists of the fields:
 class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
     """
     Interface for MCMC samplers that can be understood as automatically
-    tuning their key parameters at each step. Any other hyperparameter is 
+    tuning their key parameters at each step. Any other hyperparameter is
     assumed to be tunable via round-based adaptation.
 
     Additionally, we build native support for tempered (or annealed) sampling
@@ -96,7 +96,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
             None if init_inv_temp is None else jnp.array(init_inv_temp)
         )
         self.optimize_init_params = optimize_init_params
-    
+
     def init_state(self, initial_params, rng_key):
         """
         Initialize the state of the sampler.
@@ -109,9 +109,9 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         return AutoMCMCState(
             initial_params,
             jnp.zeros_like(x_flat),
-            jnp.array(0, x_flat.dtype), # Note: not the actual log-prior; needs to be updated 
-            jnp.array(0, x_flat.dtype), # Note: not the actual log-lik; needs to be updated 
-            jnp.array(0, x_flat.dtype), # Note: not the actual log-joint; needs to be updated 
+            jnp.array(0, x_flat.dtype), # Note: not the actual log-prior; needs to be updated
+            jnp.array(0, x_flat.dtype), # Note: not the actual log-lik; needs to be updated
+            jnp.array(0, x_flat.dtype), # Note: not the actual log-joint; needs to be updated
             rng_key,
             statistics.make_stats_recorder(x_flat, self.preconditioner),
             jnp.array(self.init_base_step_size),
@@ -121,10 +121,10 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
             None if self.init_inv_temp is None else jnp.array(self.init_inv_temp),
             None
         )
-    
+
     def init_extras(self, state):
         """
-        Carry out additional initializations not required by all 
+        Carry out additional initializations not required by all
         :class:`AutoMCMC` kernels.
         """
         return state
@@ -145,23 +145,23 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
                         jax.vmap(random.split)(rng_key), 0, 1
                     )
                 else:
-                    rng_key, rng_key_init = random.split(rng_key)                    
-                
+                    rng_key, rng_key_init = random.split(rng_key)
+
                 (
-                    new_params, 
-                    self._potential_fn, 
+                    new_params,
+                    self._potential_fn,
                     self._postprocess_fn
                 ) = initialization.init_model(
                     self._model, rng_key_init, model_args, model_kwargs
                 )
                 if initial_params is None:
                     initial_params = new_params
-                
+
                 # initialize the logprior_and_loglik function
                 self.logprior_and_loglik = partial(
-                    tempering.model_logprior_and_loglik, 
-                    self._model, 
-                    model_args, 
+                    tempering.model_logprior_and_loglik,
+                    self._model,
+                    model_args,
                     model_kwargs
                 )
             elif self._potential_fn is not None:
@@ -171,7 +171,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
                     "You need to provide a model, a logprior_and_loglik, or a " \
                     "potential function"
                 )
-        
+
         # maybe optimize the initial parameters
         if self.optimize_init_params:
             if is_vectorized:
@@ -185,8 +185,8 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
                 else {}
             )
             initial_params = initialization.optimize_init_params(
-                self.logprior_and_loglik, 
-                initial_params, 
+                self.logprior_and_loglik,
+                initial_params,
                 self.init_inv_temp,
                 **settings
             )
@@ -213,7 +213,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
     @property
     def model(self):
         return self._model
-    
+
     @abstractmethod
     def sample_single_chain(self, state, model_args, model_kwargs):
         """
@@ -233,9 +233,9 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         return self._sample_fn(state, model_args, model_kwargs)
 
     def get_diagnostics_str(self, state):
-        return "avg_ss={:.1e}, rr={:.2f}, ap={:.2f}, lj={:.1e}".format(
+        return "avg_ss={:.1e}, rr={:.2f}, ap={:.2f}, lj={: .1e}".format(
             state.stats.adapt_stats.mean_step_size,
-            state.stats.adapt_stats.rev_rate, 
+            state.stats.adapt_stats.rev_rate,
             state.stats.adapt_stats.mean_acc_prob,
             state.log_joint
         )
@@ -244,13 +244,13 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         if self._postprocess_fn is None:
             return util.identity
         return self._postprocess_fn(*model_args, **model_kwargs)
-    
+
     def kinetic_energy(self, state, precond_state):
         """
         Computes the potential energy for any auxiliary variables. The default
-        implementation assumes that the `sample` method does not modify the 
+        implementation assumes that the `sample` method does not modify the
         auxiliary variables (this is true for autoRWMH, for example). In this
-        case, the kinetic energy term cancels in the acceptance ratio so we 
+        case, the kinetic energy term cancels in the acceptance ratio so we
         can simply ignore it.
 
         :param state: Current state.
@@ -258,7 +258,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         :return: Kinetic energy.
         """
         return jnp.zeros_like(state.p_flat[0])
-    
+
     @abstractmethod
     def refresh_aux_vars(self, rng_key, state, precond_state):
         """
@@ -295,14 +295,14 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         new_temp_pot = tempering.tempered_potential_from_logprior_and_loglik(
             new_log_prior, new_log_lik, state.inv_temp
         )
-        
+
         # replace state with updated values and return
         return state._replace(
             log_prior = new_log_prior,
-            log_lik = new_log_lik,            
+            log_lik = new_log_lik,
             log_joint = -(new_temp_pot + new_kinetic_energy)
         )
-    
+
     def is_time_to_adapt(self, stats):
         round = utils.current_round(stats.n_samples)
         last_step = utils.n_steps_in_round(round)
@@ -331,7 +331,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         )
         new_stats = stats._replace(adapt_stats = new_adapt_stats)
         state = state._replace(
-            base_step_size = new_base_step_size, 
+            base_step_size = new_base_step_size,
             base_precond_state = new_base_precond_state,
             stats = new_stats
         )
@@ -346,4 +346,4 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         #     ms=new_stats.adapt_stats.mean_step_size, ma=new_stats.adapt_stats.mean_acc_prob,
         #     m=new_stats.adapt_stats.sample_mean,v=new_stats.adapt_stats.sample_var)
         return state
-    
+

--- a/automcmc/automcmc.py
+++ b/automcmc/automcmc.py
@@ -272,6 +272,10 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         """
         pass
 
+    # this is currently only used by constrained samplers
+    def postprocess_logprior_and_loglik(self, state, log_prior, log_lik):
+        return log_prior, log_lik
+
     def update_log_joint(self, state, precond_state):
         """
         Update the log-prior, log-likelihood, and log-joint.
@@ -285,6 +289,9 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
 
         # get logprior, loglik and tempered potential
         new_log_prior, new_log_lik = self.logprior_and_loglik(state.x)
+        new_log_prior, new_log_lik = self.postprocess_logprior_and_loglik(
+            state, new_log_prior, new_log_lik
+        )
         new_temp_pot = tempering.tempered_potential_from_logprior_and_loglik(
             new_log_prior, new_log_lik, state.inv_temp
         )

--- a/automcmc/autopcn.py
+++ b/automcmc/autopcn.py
@@ -50,6 +50,7 @@ class AutoPCN(autostep.AutoStep):
     In *Proceedings of the 13th AISTATS conference*, 541-548.
     """
 
+    # switch the default selector
     def __init__(
             self, 
             *args, 
@@ -57,8 +58,6 @@ class AutoPCN(autostep.AutoStep):
             **kwargs
         ):
         super().__init__(*args, selector=selector, **kwargs)
-        self._auto_step_size_fn = self.selector.gen_executor(self)
-
 
     # use the optional `idiosyncratic` field to store the sign of the angle
     def init_extras(self, state):

--- a/automcmc/autostep.py
+++ b/automcmc/autostep.py
@@ -1,13 +1,13 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional
 
 import jax
 from jax.experimental import checkify
-from jax import lax
-from jax import numpy as jnp
-from jax import random
+from jax.typing import ArrayLike
+from jax import lax, random, numpy as jnp
 
-from automcmc import selectors, statistics, utils
-from automcmc.automcmc import AutoMCMC
+from automcmc import selectors, statistics, utils, preconditioning
+from automcmc.automcmc import AutoMCMC, AutoMCMCState
 
 class AutoStep(AutoMCMC, metaclass=ABCMeta):
     """
@@ -69,38 +69,50 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         """
         return self._auto_step_size_fn(state, selector_params, precond_state)
 
+    def maybe_build_roundtrip_state(
+            self,
+            bwd_step_size: ArrayLike,
+            proposed_state: AutoMCMCState,
+            precond_state: preconditioning.PreconditionerState
+        ):
+        return None
+
     def reversibility_check(
             self,
             fwd_exponent: int,
             bwd_exponent: int,
-            *args
+            initial_state: AutoMCMCState,
+            proposed_state: AutoMCMCState,
+            roundtrip_state: Optional[AutoMCMCState]
         ) -> bool:
         """
-        Default reversibility check. Only the equality of exponents is
-        assessed. Some samplers overload this to implement more involved
+        Default reversibility check where only the equality of exponents is
+        assessed. Some samplers may override this to implement more involved
         checks.
 
         :param fwd_exponent: Forward exponent.
         :param bwd_exponent: Backward exponent.
-        :param args: Not used in default implementation.
+        :param initial_state: Initial sampler state.
+        :param proposed_state: Proposed state.
+        :param roundtrip_state: Roundtrip state.
         :return bool: True if reversibility check passed.
         """
         return fwd_exponent == bwd_exponent
 
     def next_state_accepted(self, args):
-        _, proposed_state, bwd_state = args
-
-        # keep everything from proposed_state except for stats (use bwd)
-        return proposed_state._replace(stats = bwd_state.stats)
+        _, proposed_state = args
+        return proposed_state
 
     def next_state_rejected(self, args):
-        init_state, _, bwd_state = args
+        init_state, proposed_state = args
 
         # keep everything from init_state except for stats (use bwd)
         # then do the "flip sign" part of the involution to maintain detailed
         # balance. This has no effect for samplers that fully refresh all the
-        # aux variables but it is necessary for the ones that don't (AutoPCN)
-        return self.involution_aux(init_state._replace(stats = bwd_state.stats))
+        # aux variables but it is necessary for the ones that don't
+        return self.involution_aux(
+            init_state._replace(stats = proposed_state.stats)
+        )
 
     def sample_single_chain(self, state, model_args, model_kwargs):
         """
@@ -144,28 +156,41 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
             state, selector_params, precond_state
         )
         fwd_step_size = self.step_size(state.base_step_size, fwd_exponent)
+
+        # apply full involution with fwd step and recompute log joint
         proposed_state = self.update_log_joint(
-            self.involution_main(fwd_step_size, state, precond_state),
+            self.involution_aux(
+                self.involution_main(fwd_step_size, state, precond_state)
+            ),
             precond_state
         )
 
         # backward step size search
         # don't recompute log_joint for flipped state because we assume inv_aux
         # leaves it invariant
-        prop_state_flip = self.involution_aux(proposed_state)
         if selectors.DEBUG_EXECUTOR:
             jax.debug.print("autostep backward:", ordered=True)
-        prop_state_flip, bwd_exponent = self.auto_step_size(
-            prop_state_flip, selector_params, precond_state
-        )
-        reversibility_passed = self.reversibility_check(
-            fwd_exponent, bwd_exponent, #fwd_exponent == bwd_exponent
+        proposed_state, bwd_exponent = self.auto_step_size(
+            proposed_state, selector_params, precond_state
         )
         bwd_step_size = self.step_size(state.base_step_size, bwd_exponent)
 
+        # check reversibility
+        reversibility_passed = self.reversibility_check(
+            fwd_exponent,
+            bwd_exponent,
+            state,
+            proposed_state,
+            self.maybe_build_roundtrip_state(
+                bwd_step_size, proposed_state, precond_state
+            )
+        )
+
         # sanitize possible nan in proposed log joint, setting them to -inf
-        # this may happen for some too large initial step sizes, and then
-        # `shrink_step_size` may fail to fix them before the max num of iters
+        # this may happen for some too large initial step sizes, which
+        # `shrink_step_size` may fail to fix before hitting max num of iters
+        # can also happen when fwd involution outright fails, as in the case of
+        # constrained samplers
         proposed_log_joint = jnp.where(
             jnp.isnan(proposed_state.log_joint),
             -jnp.inf,
@@ -196,7 +221,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
             random.bernoulli(accept_key, acc_prob),
             self.next_state_accepted,
             self.next_state_rejected,
-            (state, proposed_state, prop_state_flip)
+            (state, proposed_state)
         )
 
         # collect statistics

--- a/automcmc/autostep.py
+++ b/automcmc/autostep.py
@@ -33,7 +33,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
     @abstractmethod
     def involution_main(self, step_size, state, precond_state):
         """
-        Apply the main part of the involution. This is usually the part that 
+        Apply the main part of the involution. This is usually the part that
         modifies the variables of interests.
 
         :param step_size: Step size to use in the involutive transformation.
@@ -42,7 +42,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         :return: Updated state.
         """
         pass
-    
+
     @abstractmethod
     def involution_aux(self, state):
         """
@@ -55,10 +55,10 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         :return: Updated state.
         """
         pass
-    
+
     def auto_step_size(self, state, selector_params, precond_state):
         """
-        Find an appropriate step size using the criterion defined by the 
+        Find an appropriate step size using the criterion defined by the
         `selector`, and depending on the `state` and `selector parameters`.
 
         :param state: Current state.
@@ -68,19 +68,32 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         :return: A step size.
         """
         return self._auto_step_size_fn(state, selector_params, precond_state)
-    
+
+    def reversibility_check(fwd_exponent, bwd_exponent, *args) -> bool:
+        """
+        Default reversibility check. Only the equality of exponents is
+        assessed. Some samplers overload this to implement more involved
+        checks.
+
+        :param fwd_exponent: Forward exponent.
+        :param bwd_exponent: Backward exponent.
+        :param args: Not used in default implementation.
+        :return bool: True if reversibility check passed.
+        """
+        return fwd_exponent == bwd_exponent
+
     def next_state_accepted(self, args):
         _, proposed_state, bwd_state = args
 
         # keep everything from proposed_state except for stats (use bwd)
         return proposed_state._replace(stats = bwd_state.stats)
-    
+
     def next_state_rejected(self, args):
         init_state, _, bwd_state = args
-        
+
         # keep everything from init_state except for stats (use bwd)
         # then do the "flip sign" part of the involution to maintain detailed
-        # balance. This has no effect for samplers that fully refresh all the 
+        # balance. This has no effect for samplers that fully refresh all the
         # aux variables but it is necessary for the ones that don't (AutoPCN)
         return self.involution_aux(init_state._replace(stats = bwd_state.stats))
 
@@ -95,10 +108,10 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         """
         # generate rng keys and store the updated master key in the state
         (
-            rng_key, 
-            precond_key, 
+            rng_key,
+            precond_key,
             aux_key,
-            selector_key, 
+            selector_key,
             accept_key
         ) = random.split(state.rng_key, 5)
         state = state._replace(rng_key = rng_key)
@@ -108,7 +121,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
             state.base_precond_state, precond_key
         )
 
-        # refresh auxiliary variables (e.g., momentum), update the log joint 
+        # refresh auxiliary variables (e.g., momentum), update the log joint
         # density, and finally check if the latter is finite
         # Checker needs checkifying twice for some reason
         state = self.update_log_joint(
@@ -132,7 +145,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         )
 
         # backward step size search
-        # don't recompute log_joint for flipped state because we assume inv_aux 
+        # don't recompute log_joint for flipped state because we assume inv_aux
         # leaves it invariant
         prop_state_flip = self.involution_aux(proposed_state)
         if selectors.DEBUG_EXECUTOR:
@@ -140,11 +153,13 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         prop_state_flip, bwd_exponent = self.auto_step_size(
             prop_state_flip, selector_params, precond_state
         )
-        reversibility_passed = fwd_exponent == bwd_exponent
+        reversibility_passed = self.reversibility_check(
+            fwd_exponent, bwd_exponent, #fwd_exponent == bwd_exponent
+        )
         bwd_step_size = self.step_size(state.base_step_size, bwd_exponent)
 
         # sanitize possible nan in proposed log joint, setting them to -inf
-        # this may happen for some too large initial step sizes, and then 
+        # this may happen for some too large initial step sizes, and then
         # `shrink_step_size` may fail to fix them before the max num of iters
         proposed_log_joint = jnp.where(
             jnp.isnan(proposed_state.log_joint),
@@ -166,7 +181,7 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
             jax.debug.print(
                 "reversible? {}, acc_prob={}, fwd_step_size={}",
                 reversibility_passed,
-                acc_prob, 
+                acc_prob,
                 fwd_step_size,
                 ordered=True
             )
@@ -192,4 +207,3 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
 
         return next_state
 
-    

--- a/automcmc/autostep.py
+++ b/automcmc/autostep.py
@@ -69,7 +69,12 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         """
         return self._auto_step_size_fn(state, selector_params, precond_state)
 
-    def reversibility_check(fwd_exponent, bwd_exponent, *args) -> bool:
+    def reversibility_check(
+            self,
+            fwd_exponent: int,
+            bwd_exponent: int,
+            *args
+        ) -> bool:
         """
         Default reversibility check. Only the equality of exponents is
         assessed. Some samplers overload this to implement more involved

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -177,7 +177,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # prefer using only rtol, but need to have atol>0 if the origin
         # satisfies the constraint
         if 'rtol' not in self.x_tols:
-            self.x_tols['rtol'] = jnp.sqrt(jnp.finfo(x_flat.dtype).eps)
+            self.x_tols['rtol'] = jnp.cbrt(jnp.finfo(x_flat.dtype).eps)
         if 'atol' not in self.x_tols:
             self.x_tols['atol'] = len(x_flat)*self.solver_options['tol'] # recommended in Xu&Holmes-Cerfon(2024)
 
@@ -220,9 +220,16 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         log_lik = jnp.where(cs.is_satisfied, log_lik, -jnp.inf)
         return log_prior, log_lik
 
+    # check closeness of ambient space vectors by using a symmetric check
+    # (i.e., invariant to flipping x<->y) based on L^2-norms
+    # better than jnp.allclose which is == all(jnp.isclose)
     def close_in_ambient_space(self, x, y):
-        return jnp.allclose(
-            x, y, atol=self.x_tols['atol'], rtol=self.x_tols['rtol']
+        diff_norm = jnp.linalg.norm(x-y)
+        x_norm = jnp.linalg.norm(x)
+        y_norm = jnp.linalg.norm(y)
+        return diff_norm < jnp.maximum(
+            self.x_tols['atol'],
+            self.x_tols['rtol']*jnp.maximum(x_norm, y_norm)
         )
 
     def maybe_build_roundtrip_state(

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,0 +1,53 @@
+import jax
+from jax.typing import ArrayLike
+import jax.numpy as jnp
+
+class JacobianOperator:
+    """
+    Implements several linear algebraic operations associated with :math:`J_x`,
+    the Jacobian of a function evaluated at a point :math:`x`.
+
+    Attributes:
+        Q: Q factor of the QR decomposition of :math:`J_x^T`.
+        log_abs_det: log of :math:`|(J_xJ_x^T)|^{-1/2}` computed using the
+            R factor of the QR decomposition.
+    """
+
+    def __init__(self, J: ArrayLike):
+        """
+        Build the operator from the Jacobian evaluated at a point on the
+        level set.
+
+        :param J: Jacobian matrix of shape `(m,n)` with `m<n`.
+        """
+        m, n = jnp.shape(J)
+        assert m < n
+        Q,R = jnp.linalg.qr(J.T)
+        self.Q = Q
+        self.log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
+    
+    # project onto normal (N) space
+    # P[N]v = J^T(JJ^T)^{-1}Jv = Q(Q^Tv)
+    # Cost: O(mn^2 + nm^2)
+    def proj_normal(self, v: ArrayLike) -> jax.Array:
+        """
+        Project a vector onto the normal space at `x`.
+
+        :param v: vector of length `n`.
+        :return: normal component of `v`.
+        """
+        return self.Q @ jnp.dot(v, self.Q)
+
+    # project onto normal (N) and tangent (T) spaces
+    # P[T] = v - P[N]v
+    # Cost: O(mn^2 + nm^2)
+    def proj_normal_tangent(self, v: ArrayLike) -> tuple[jax.Array, jax.Array]:
+        """
+        Project a vector onto the normal and tangent spaces at `x`.
+
+        :param v: vector of length `n`.
+        :return: normal and tangent components of `v`.
+        """
+        PNv = self.proj_normal(v)
+        return (PNv, v - PNv)
+

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -44,7 +44,7 @@ def make_constraint_state(
     is_satisfied = utils.newton_fn_value_err(f_val) < tol
     m, n = jnp.shape(J)
     assert m < n
-    chol = jax.lax.linalg.cholesky(jnp.inner(J,J), symmetrize_input=False) # (JJ^T)^T=JJ^T -> no need to force it
+    chol = jax.lax.linalg.cholesky(jnp.inner(J,J))
     log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
     return ConstraintState(is_satisfied, x_base, chol, log_abs_det)
 

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, Callable
 
 import jax
 from jax.typing import ArrayLike
@@ -13,56 +13,88 @@ class ConstraintState(NamedTuple):
     evaluated at a specific point in space.
 
     Attributes:
-        is_satisfied: true if the constraint is satisfied up to tolerance.
-        Q: Q factor of the QR decomposition of :math:`J_x^T` where :math:`J_x`
-            is the Jacobian evaluated at :math:`x`. Used for projection onto
-            normal space.
+        is_satisfied: true if `f(x_base)=0` up to tolerance.
+        x_base: point that dictates the level set :math:`f^{-1}(\\{x\\})` and
+            the tangent and normal spaces that determine the projections onto
+            said level set. We assume `x_base` is flattened.
+        chol: Cholesky decomposition of :math:`J_xJ_x^T` where :math:`J_x`
+            is the Jacobian of the constraint evaluated at `x_base`.
         log_abs_det: log of :math:`|(J_xJ_x^T)|^{-1/2}` computed using the
-            R factor of the QR decomposition.
+            Cholesky decomposition.
     """
     is_satisfied: ArrayLike
-    Q: ArrayLike
-    log_abs_det: ArrayLike
+    x_base: ArrayLike
+    chol: jax.Array
+    log_abs_det: jax.Array
 
-def make_constraint_state(is_satisfied: ArrayLike, J: ArrayLike):
+def make_constraint_state(
+        constraint_fn: Callable[[ArrayLike], jax.Array],
+        x_base: ArrayLike,
+        tol: ArrayLike
+    ) -> ConstraintState:
     """
     Build :class:`ConstraintState`.
 
-    :param is_satisfied: is the constraint satisfied?
-    :param J: Jacobian matrix of shape `(m,n)` with `m<n`.
+    :param constraint_fn: the constraint function.
+    :param x_base: base point; see :class:`ConstraintState`.
+    :param tol: tolerance for constraint satisfiability.
+    :return: a :class:`ConstraintState` corresponding to `x_base`.
     """
+    J, f_val = jax.jacrev(lambda x: 2*(constraint_fn(x),),has_aux=True)(x_base) # get Jacobian and value in one pass
+    is_satisfied = utils.newton_fn_value_err(f_val) < tol
     m, n = jnp.shape(J)
     assert m < n
-    Q,R = jnp.linalg.qr(J.T)
-    log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
-    return ConstraintState(is_satisfied, Q, log_abs_det)
+    chol = jax.lax.linalg.cholesky(jnp.inner(J,J), symmetrize_input=False) # (JJ^T)^T=JJ^T -> no need to force it
+    log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
+    return ConstraintState(is_satisfied, x_base, chol, log_abs_det)
 
 # project onto normal (N) space
-# P[N]v = J^T(JJ^T)^{-1}Jv = Q(Q^Tv)
-# Cost: O(mn^2 + nm^2)
-def proj_normal(cs: ConstraintState, v: ArrayLike) -> jax.Array:
+#   P[N]v = J^T(JJ^T)^{-1}Jv
+# Following Xu&Holmes-Cerfon(2024), we can do this in steps
+#   1) u = Jv --> single jvp, O(1 func eval). For norm-like f, this is O(nm)
+#   2) solve for w: LL^Tw=u <=> w = L^{-T}[L^{-1}u]
+#                           <=> t=L^{-1}u and w=L^{-T}t
+#       a) O(m^2) triangular solve for t: Lt = u
+#       b) O(m^2) triangular solve for w: L^Tw=t
+#   3) P[N]v = J^Tw = (w^TJ)^T --> single vjp, O(1 func eval)
+# Cost: O(nm + m^2)
+def proj_normal(
+        constraint_fn: Callable[[ArrayLike], jax.Array],
+        cs: ConstraintState,
+        v: ArrayLike
+    ) -> jax.Array:
     """
-    Project a vector onto the normal space at `x`.
+    Project a vector onto the normal space at `cs.x_base`.
 
-    :param v: vector of length `n`.
+    :param constraint_fn: the constraint function.
+    :param cs: a :class:`ConstraintState` dictating the normal space.
+    :param v: vector to project.
     :return: normal component of `v`.
     """
-    return cs.Q @ jnp.dot(v, cs.Q)
+    u = jax.jvp(constraint_fn, (cs.x_base,), (v,))[-1]
+    t = jax.lax.linalg.triangular_solve(cs.chol, u, lower=True) # == jnp.linalg.solve(cs.chol, u)
+    w = jax.lax.linalg.triangular_solve(
+        cs.chol, t, lower=True, transpose_a=True # == jnp.linalg.solve(cs.chol.T, t)
+    )
+    f_vjp = jax.vjp(constraint_fn, cs.x_base)[-1]
+    return f_vjp(w)[0]
 
 # project onto normal (N) and tangent (T) spaces
-# P[T] = v - P[N]v
-# Cost: O(mn^2 + nm^2)
+# same as cost of just doing the normal part
 def proj_normal_tangent(
+        constraint_fn: Callable[[ArrayLike], jax.Array],
         cs: ConstraintState,
         v: ArrayLike
     ) -> tuple[jax.Array, jax.Array]:
     """
-    Project a vector onto the normal and tangent spaces at `x`.
+    Project a vector onto the normal and tangent spaces at `cs.x_base`.
 
-    :param v: vector of length `n`.
+    :param constraint_fn: the constraint function.
+    :param cs: a :class:`ConstraintState` dictating the normal space.
+    :param v: vector to project.
     :return: normal and tangent components of `v`.
     """
-    PNv = proj_normal(cs, v)
+    PNv = proj_normal(constraint_fn, cs, v)
     return (PNv, v - PNv)
 
 
@@ -100,33 +132,35 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         self.solver_options = solver_options
         self.x_tols = x_tols
 
-    # TODO: using vjp for J^Tz=(z^TJ)^T instead of Qz would be more memory
-    # efficient **if** we can get rid of Q in projection to tangent space
     def proj_level_set(
             self,
             x_flat: ArrayLike,
             cs: ConstraintState
         ) -> tuple:
         """
-        Project a point on the constraint set
+        Project a point on the constraint level set along the normal space
+        determined by a :class:`ConstraintState`.
 
         :param ArrayLike x_flat: a vector.
-        :param ConstraintState cs: a :class:`ConstraintState`.
+        :param ConstraintState cs: a :class:`ConstraintState` corresponding to
+            the base point which dictates the normal spaces.
         :return tuple: projected vector, updated :class:`ConstraintState`, and
             solver diagnostics.
         """
-        # project the initial point to the feasible set
-        #   solve for z: 0 = f(x + Qz) => set x' = x + Qz
-        z, *diagnostics, is_satisfied = utils.newton(
-            lambda z: self.constraint_fn(x_flat + cs.Q @ z),
-            jnp.zeros(cs.Q.shape[-1], cs.Q.dtype),
+        # project to the feasible set in the normal directions at cs.x_base
+        #   solve for z: 0 = f(x + J^Tz) => set x' = x + J^Tz
+        # since J^Tz = (z^TJ)^T, we can use vector-Jacobian prods (vjp)
+        f_val, f_vjp = jax.vjp(self.constraint_fn, cs.x_base)
+        z, *diagnostics, _ = utils.newton(
+            lambda z: self.constraint_fn(x_flat + f_vjp(z)[0]),
+            jnp.zeros_like(f_val),
             **self.solver_options
         )
-        x_flat += cs.Q @ z
+        x_flat += f_vjp(z)[0]
 
         # update the constraint state and return
         cs = make_constraint_state(
-            is_satisfied, jax.jacrev(self.constraint_fn)(x_flat)
+            self.constraint_fn, x_flat, self.solver_options['tol']
         )
         return (x_flat, cs, diagnostics)
 
@@ -149,7 +183,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
 
         # initialize the constraint state
         cs = make_constraint_state(
-            False, jax.jacrev(self.constraint_fn)(x_flat)
+            self.constraint_fn, x_flat, self.solver_options['tol']
         )
 
         # project to zero level set
@@ -170,6 +204,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def refresh_aux_vars(self, rng_key, state, precond_state):
         return state._replace(
             p_flat = proj_normal_tangent(
+                self.constraint_fn,
                 state.idiosyncratic,
                 random.normal(rng_key, jnp.shape(state.p_flat))
             )[-1]
@@ -246,7 +281,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # onto the tangent space at the new point
         # note: the displacement is on scale step_size * v, so we must divide
         # by the step size to get the right scale
-        v_flat = proj_normal_tangent(cs, x_flat_new - x_flat)[-1] / step_size
+        v_flat = proj_normal_tangent(
+            self.constraint_fn, cs, x_flat_new - x_flat
+        )[-1] / step_size
 
         # update state and return
         return state._replace(

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -4,7 +4,8 @@ import jax
 from jax.typing import ArrayLike
 from jax import flatten_util, random, numpy as jnp
 
-from automcmc import utils, autostep, preconditioning, automcmc
+from automcmc import utils, autostep, preconditioning
+from automcmc.automcmc import AutoMCMCState
 
 class ConstraintState(NamedTuple):
     """
@@ -178,38 +179,42 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         tol = self.solver_options['tol']
         return jnp.allclose(x, y, atol=10*tol, rtol=0.01)
 
+    def maybe_build_roundtrip_state(
+            self,
+            bwd_step_size: ArrayLike,
+            prop_state_flip: AutoMCMCState,
+            precond_state: preconditioning.PreconditionerState
+        ):
+        return self.involution_aux(
+            self.involution_main(bwd_step_size, prop_state_flip, precond_state)
+        )
+
     def reversibility_check(
             self,
             fwd_exponent: int,
             bwd_exponent: int,
-            initial_state: automcmc.AutoMCMCState,
-            proposed_state: automcmc.AutoMCMCState
+            initial_state: AutoMCMCState,
+            proposed_state: AutoMCMCState,
+            roundtrip_state: AutoMCMCState
         ) -> bool:
-        """
-        Implement the additional checks required by constrained sampling.
-
-        :param fwd_exponent: Forward exponent.
-        :param bwd_exponent: Backward exponent.
-        :param initial_state: Initial sampler state.
-        :param proposed_state: Proposed state.
-        :return bool: True if reversibility check passed.
-        """
         passed = fwd_exponent == bwd_exponent
         passed = jnp.logical_and(
             passed, proposed_state.idiosyncratic.is_satisfied
         )
         passed = jnp.logical_and(
+            passed, roundtrip_state.idiosyncratic.is_satisfied
+        )
+        passed = jnp.logical_and(
             passed,
             self.close_in_ambient_space(
                 flatten_util.ravel_pytree(initial_state.x)[0],
-                flatten_util.ravel_pytree(proposed_state.x)[0]
+                flatten_util.ravel_pytree(roundtrip_state.x)[0]
             )
         )
         return jnp.logical_and(
             passed,
             self.close_in_ambient_space(
-                initial_state.p_flat,
-                proposed_state.p_flat
+                initial_state.p_flat, roundtrip_state.p_flat
             )
         )
 

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -4,7 +4,7 @@ import jax
 from jax.typing import ArrayLike
 from jax import flatten_util, random, numpy as jnp
 
-from automcmc import utils, autostep, preconditioning
+from automcmc import utils, autostep, preconditioning, automcmc
 
 class ConstraintState(NamedTuple):
     """
@@ -174,6 +174,46 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         log_lik = jnp.where(cs.is_satisfied, log_lik, -jnp.inf)
         return log_prior, log_lik
 
+    def close_in_ambient_space(self, x, y):
+        tol = self.solver_options['tol']
+        return jnp.allclose(x, y, atol=10*tol, rtol=0.01)
+
+    def reversibility_check(
+            self,
+            fwd_exponent: int,
+            bwd_exponent: int,
+            initial_state: automcmc.AutoMCMCState,
+            proposed_state: automcmc.AutoMCMCState
+        ) -> bool:
+        """
+        Implement the additional checks required by constrained sampling.
+
+        :param fwd_exponent: Forward exponent.
+        :param bwd_exponent: Backward exponent.
+        :param initial_state: Initial sampler state.
+        :param proposed_state: Proposed state.
+        :return bool: True if reversibility check passed.
+        """
+        passed = fwd_exponent == bwd_exponent
+        passed = jnp.logical_and(
+            passed, proposed_state.idiosyncratic.is_satisfied
+        )
+        passed = jnp.logical_and(
+            passed,
+            self.close_in_ambient_space(
+                flatten_util.ravel_pytree(initial_state.x)[0],
+                flatten_util.ravel_pytree(proposed_state.x)[0]
+            )
+        )
+        return jnp.logical_and(
+            passed,
+            self.close_in_ambient_space(
+                initial_state.p_flat,
+                proposed_state.p_flat
+            )
+        )
+
+
     # Both position and velocity are affected by this transform
     #   - position is updated by moving along velocity and projecting
     #   - velocity is updated by projecting the displacement vector
@@ -203,5 +243,3 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     # to the new tangent space in `involution_main`
     def involution_aux(self, state):
         return state._replace(p_flat = -state.p_flat)
-
-

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,54 +1,200 @@
+from typing import NamedTuple
+
 import jax
 from jax.typing import ArrayLike
-import jax.numpy as jnp
+from jax import flatten_util, random, numpy as jnp
 
-from automcmc import utils
+from automcmc import utils, autostep, tempering
 
-class JacobianOperator:
+class ConstraintState(NamedTuple):
     """
-    Implements several linear algebraic operations associated with :math:`J_x`,
-    the Jacobian of a function evaluated at a point :math:`x`.
+    A :class:`NamedTuple` type for storing constraint-related quantities
+    evaluated at a specific point in space.
 
     Attributes:
-        Q: Q factor of the QR decomposition of :math:`J_x^T`.
+        is_satisfied: true if the constraint is satisfied up to tolerance.
+        Q: Q factor of the QR decomposition of :math:`J_x^T` where :math:`J_x`
+            is the Jacobian evaluated at :math:`x`. Used for projection onto
+            normal space.
         log_abs_det: log of :math:`|(J_xJ_x^T)|^{-1/2}` computed using the
             R factor of the QR decomposition.
     """
+    is_satisfied: ArrayLike
+    Q: ArrayLike
+    log_abs_det: ArrayLike
 
-    def __init__(self, J: ArrayLike):
-        """
-        Build the operator from the Jacobian evaluated at a point on the
-        level set.
+def make_constraint_state(is_satisfied: ArrayLike, J: ArrayLike):
+    """
+    Build :class:`ConstraintState`.
 
-        :param J: Jacobian matrix of shape `(m,n)` with `m<n`.
-        """
-        m, n = jnp.shape(J)
-        assert m < n
-        Q,R = jnp.linalg.qr(J.T)
-        self.Q = Q
-        self.log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
-    
-    # project onto normal (N) space
-    # P[N]v = J^T(JJ^T)^{-1}Jv = Q(Q^Tv)
-    # Cost: O(mn^2 + nm^2)
-    def proj_normal(self, v: ArrayLike) -> jax.Array:
-        """
-        Project a vector onto the normal space at `x`.
+    :param is_satisfied: is the constraint satisfied?
+    :param J: Jacobian matrix of shape `(m,n)` with `m<n`.
+    """
+    m, n = jnp.shape(J)
+    assert m < n
+    Q,R = jnp.linalg.qr(J.T)
+    log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
+    return ConstraintState(is_satisfied, Q, log_abs_det)
 
-        :param v: vector of length `n`.
-        :return: normal component of `v`.
-        """
-        return self.Q @ jnp.dot(v, self.Q)
+# project onto normal (N) space
+# P[N]v = J^T(JJ^T)^{-1}Jv = Q(Q^Tv)
+# Cost: O(mn^2 + nm^2)
+def proj_normal(cs: ConstraintState, v: ArrayLike) -> jax.Array:
+    """
+    Project a vector onto the normal space at `x`.
 
-    # project onto normal (N) and tangent (T) spaces
-    # P[T] = v - P[N]v
-    # Cost: O(mn^2 + nm^2)
-    def proj_normal_tangent(self, v: ArrayLike) -> tuple[jax.Array, jax.Array]:
-        """
-        Project a vector onto the normal and tangent spaces at `x`.
+    :param v: vector of length `n`.
+    :return: normal component of `v`.
+    """
+    return cs.Q @ jnp.dot(v, cs.Q)
 
-        :param v: vector of length `n`.
-        :return: normal and tangent components of `v`.
+# project onto normal (N) and tangent (T) spaces
+# P[T] = v - P[N]v
+# Cost: O(mn^2 + nm^2)
+def proj_normal_tangent(
+        cs: ConstraintState,
+        v: ArrayLike
+    ) -> tuple[jax.Array, jax.Array]:
+    """
+    Project a vector onto the normal and tangent spaces at `x`.
+
+    :param v: vector of length `n`.
+    :return: normal and tangent components of `v`.
+    """
+    PNv = proj_normal(cs, v)
+    return (PNv, v - PNv)
+
+
+class AutoConstrainedRWMH(autostep.AutoStep):
+    """
+    Implementation of constrained random walk Metropolis-Hastings as described
+    in [1,2], within an AutoStep framework for automatic selection of the
+    proposal step size.
+
+    .. rubric:: References
+
+    [1] Zappa, E., Holmes-Cerfon, M. & Goodman, J. (2018).
+    Monte Carlo on manifolds: Sampling densities and integrating functions.
+    *Comm. Pure Appl. Math.*, 71, 2609-2647.
+
+    [2] Xu, K., & Holmes-Cerfon, M. (2024). Monte Carlo on manifolds in high
+    dimensions. *Journal of Computational Physics*, 506, 112939.
+    """
+
+    def __init__(
+            self,
+            *args,
+            constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
+            solver_options = {},
+            **kwargs
+        ):
+        super().__init__(*args, **kwargs)
+        self.constraint_fn = constraint_fn
+        self.solver_options = solver_options
+
+    def proj_level_set(
+            self,
+            x_flat: ArrayLike,
+            cs: ConstraintState
+        ) -> tuple:
         """
-        PNv = self.proj_normal(v)
-        return (PNv, v - PNv)
+        Project a point on the constraint set
+
+        :param ArrayLike x_flat: a vector.
+        :param ConstraintState cs: a :class:`ConstraintState`.
+        :return tuple: projected vector, updated :class:`ConstraintState`, and
+            solver diagnostics.
+        """
+        # project the initial point to the feasible set
+        #   solve for z: 0 = f(x + Qz) => set x' = x + Qz
+        z, *diagnostics, is_satisfied = utils.newton(
+            lambda z: self.constraint_fn(x_flat + cs.Q @ z),
+            jnp.zeros(cs.Q.shape[-1], cs.Q.dtype),
+            **self.solver_options
+        )
+        x_flat += cs.Q @ z
+
+        # update the constraint state and return
+        cs = make_constraint_state(
+            is_satisfied, jax.jacrev(self.constraint_fn)(x_flat)
+        )
+        return (x_flat, cs, diagnostics)
+
+    def init_extras(self, state):
+        # TODO: extract constraint_fn for numpyro models (via a deterministic
+        # stmtnt+model_kwargs or a Delta dist (problem: breaks log_prob))
+
+        # set the constraint tolerance
+        x_flat, unravel_fn = flatten_util.ravel_pytree(state.x)
+        if 'tol' not in self.solver_options:
+            self.solver_options['tol'] = utils.newton_default_tol(x_flat)
+
+        # initialize the constraint state
+        cs = make_constraint_state(
+            False, jax.jacrev(self.constraint_fn)(x_flat)
+        )
+
+        # project to manifold
+        x_flat, cs, diagnostics = self.proj_level_set(x_flat, cs)
+        if not cs.is_satisfied:
+            raise ValueError(
+                "Cannot find feasible starting point. " \
+                f"Solver output:\n{diagnostics}"
+            )
+
+        # return updated state
+        return state._replace(x = unravel_fn(x_flat), idiosyncratic = cs)
+
+    def kinetic_energy(self, state, precond_state):
+        return 0.5*jnp.dot(state.p_flat, state.p_flat)
+
+    # sample and project to tangent space
+    def refresh_aux_vars(self, rng_key, state, precond_state):
+        return state._replace(
+            p_flat = proj_normal_tangent(
+                state.idiosyncratic,
+                random.normal(rng_key, jnp.shape(state.p_flat))
+            )[-1]
+        )
+
+    # need to
+    #   - add the log of the co-area formula factor
+    #   - make the likelihood 0 when err > tol so that solver failures are
+    #     handled gracefully by the autostep machinery
+    def postprocess_logprior_and_loglik(self, state, log_prior, log_lik):
+        cs = state.idiosyncratic
+        log_prior += cs.log_abs_det
+        log_lik = jnp.where(cs.is_satisfied, log_lik, -jnp.inf)
+        return log_prior, log_lik
+
+    # Both position and velocity are affected by this transform
+    #   - position is updated by moving along velocity and projecting
+    #   - velocity is updated by projecting the displacement vector
+    def involution_main(self, step_size, state, precond_state):
+        # move outside the level set: x <- x+s*v
+        x_flat, unravel_fn = flatten_util.ravel_pytree(state.x)
+        v_flat = state.p_flat
+        x_flat_out = x_flat + step_size * v_flat
+
+        # project back to level set
+        x_flat_new,cs,_ = self.proj_level_set(x_flat_out, state.idiosyncratic)
+
+        # transport the velocity by projecting the displacement vector x'-x
+        # onto the tangent space at the new point
+        # note: the displacement is on scale step_size * v, so we must divide
+        # by the step size to get the right scale
+        v_flat = proj_normal_tangent(cs, x_flat_new - x_flat)[-1] / step_size
+
+        # update state and return
+        return state._replace(
+            x = unravel_fn(x_flat_new),
+            p_flat = v_flat,
+            idiosyncratic = cs
+        )
+
+    # only need to flip sign of the velocity, which was already transported
+    # to the new tangent space in `involution_main`
+    def involution_aux(self, state):
+        return state._replace(p_flat = -state.p_flat)
+
+

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -88,6 +88,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             preconditioner=preconditioning.IdentityDiagonalPreconditioner(), # we need rotational symmetry
             constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
             solver_options = {},
+            x_tols = {},
             **kwargs
         ):
         super().__init__(*args,preconditioner=preconditioner,**kwargs)
@@ -97,6 +98,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
           f" but I got instead {type(self.preconditioner)}"
         self.constraint_fn = constraint_fn
         self.solver_options = solver_options
+        self.x_tols = x_tols
 
     # TODO: using vjp for J^Tz=(z^TJ)^T instead of Qz would be more memory
     # efficient **if** we can get rid of Q in projection to tangent space
@@ -137,12 +139,27 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         if 'tol' not in self.solver_options:
             self.solver_options['tol'] = utils.newton_default_tol(x_flat)
 
+        # set the ambient space tolerances (`allclose` parameters)
+        # prefer using only rtol, but need to have atol>0 if the origin
+        # satisfies the constraint
+        if 'rtol' not in self.x_tols:
+            self.x_tols['rtol'] = jnp.sqrt(jnp.finfo(x_flat.dtype).eps)
+        if 'atol' not in self.x_tols:
+            fn_err_at_origin = utils.newton_fn_value_err(
+                self.constraint_fn(jnp.zeros_like(x_flat))
+            )
+            self.x_tols['atol'] = (
+                jnp.zeros_like(self.x_tols['rtol'])
+                if fn_err_at_origin >= self.solver_options['tol']
+                else len(x_flat)*self.solver_options['tol'] # recommended in Xu&Holmes-Cerfon(2024)
+            )
+
         # initialize the constraint state
         cs = make_constraint_state(
             False, jax.jacrev(self.constraint_fn)(x_flat)
         )
 
-        # project to manifold
+        # project to zero level set
         x_flat, cs, diagnostics = self.proj_level_set(x_flat, cs)
         if not cs.is_satisfied:
             raise ValueError(
@@ -167,8 +184,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
 
     # need to
     #   - add the log of the co-area formula factor
-    #   - make the likelihood 0 when err > tol so that solver failures are
-    #     handled gracefully by the autostep machinery
+    #   - make the likelihood 0 when constraint is not satisfied, so that
+    #     solver failures are handled gracefully by the autostep executors
     def postprocess_logprior_and_loglik(self, state, log_prior, log_lik):
         cs = state.idiosyncratic
         log_prior += cs.log_abs_det
@@ -176,8 +193,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         return log_prior, log_lik
 
     def close_in_ambient_space(self, x, y):
-        tol = self.solver_options['tol']
-        return jnp.allclose(x, y, atol=10*tol, rtol=0.01)
+        return jnp.allclose(
+            x, y, atol=self.x_tols['atol'], rtol=self.x_tols['rtol']
+        )
 
     def maybe_build_roundtrip_state(
             self,

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -4,7 +4,7 @@ import jax
 from jax.typing import ArrayLike
 from jax import flatten_util, random, numpy as jnp
 
-from automcmc import utils, autostep, tempering
+from automcmc import utils, autostep, preconditioning
 
 class ConstraintState(NamedTuple):
     """
@@ -84,14 +84,20 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def __init__(
             self,
             *args,
+            preconditioner=preconditioning.IdentityDiagonalPreconditioner, # we need rotational symmetry
             constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
             solver_options = {},
             **kwargs
         ):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args,preconditioner=preconditioner,**kwargs)
+        assert isinstance(
+            self.preconditioner, preconditioning.IdentityDiagonalPreconditioner
+        ), "This method is justified only for `IdentityDiagonalPreconditioner`"
         self.constraint_fn = constraint_fn
         self.solver_options = solver_options
 
+    # TODO: using vjp for J^Tz=(z^TJ)^T instead of Qz would be more memory
+    # efficient **if** we can get rid of Q in projection to tangent space
     def proj_level_set(
             self,
             x_flat: ArrayLike,

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -2,6 +2,8 @@ import jax
 from jax.typing import ArrayLike
 import jax.numpy as jnp
 
+from automcmc import utils
+
 class JacobianOperator:
     """
     Implements several linear algebraic operations associated with :math:`J_x`,
@@ -50,4 +52,3 @@ class JacobianOperator:
         """
         PNv = self.proj_normal(v)
         return (PNv, v - PNv)
-

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -84,7 +84,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def __init__(
             self,
             *args,
-            preconditioner=preconditioning.IdentityDiagonalPreconditioner, # we need rotational symmetry
+            preconditioner=preconditioning.IdentityDiagonalPreconditioner(), # we need rotational symmetry
             constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
             solver_options = {},
             **kwargs
@@ -92,7 +92,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         super().__init__(*args,preconditioner=preconditioner,**kwargs)
         assert isinstance(
             self.preconditioner, preconditioning.IdentityDiagonalPreconditioner
-        ), "This method is justified only for `IdentityDiagonalPreconditioner`"
+        ), "This method is justified only for `IdentityDiagonalPreconditioner`" \
+          f" but I got instead {type(self.preconditioner)}"
         self.constraint_fn = constraint_fn
         self.solver_options = solver_options
 

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -145,14 +145,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         if 'rtol' not in self.x_tols:
             self.x_tols['rtol'] = jnp.sqrt(jnp.finfo(x_flat.dtype).eps)
         if 'atol' not in self.x_tols:
-            fn_err_at_origin = utils.newton_fn_value_err(
-                self.constraint_fn(jnp.zeros_like(x_flat))
-            )
-            self.x_tols['atol'] = (
-                jnp.zeros_like(self.x_tols['rtol'])
-                if fn_err_at_origin >= self.solver_options['tol']
-                else len(x_flat)*self.solver_options['tol'] # recommended in Xu&Holmes-Cerfon(2024)
-            )
+            self.x_tols['atol'] = len(x_flat)*self.solver_options['tol'] # recommended in Xu&Holmes-Cerfon(2024)
 
         # initialize the constraint state
         cs = make_constraint_state(

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -177,9 +177,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # prefer using only rtol, but need to have atol>0 if the origin
         # satisfies the constraint
         if 'rtol' not in self.x_tols:
-            self.x_tols['rtol'] = jnp.cbrt(jnp.finfo(x_flat.dtype).eps)
+            self.x_tols['rtol'] = jnp.finfo(x_flat.dtype).eps**0.25
         if 'atol' not in self.x_tols:
-            self.x_tols['atol'] = len(x_flat)*self.solver_options['tol'] # recommended in Xu&Holmes-Cerfon(2024)
+            self.x_tols['atol'] = self.solver_options['tol'] # this val already scales with size of problem so no need to scale again
 
         # initialize the constraint state
         cs = make_constraint_state(
@@ -224,13 +224,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     # (i.e., invariant to flipping x<->y) based on L^2-norms
     # better than jnp.allclose which is == all(jnp.isclose)
     def close_in_ambient_space(self, x, y):
-        diff_norm = jnp.linalg.norm(x-y)
-        x_norm = jnp.linalg.norm(x)
-        y_norm = jnp.linalg.norm(y)
-        return diff_norm < jnp.maximum(
-            self.x_tols['atol'],
-            self.x_tols['rtol']*jnp.maximum(x_norm, y_norm)
-        )
+        return utils.close_in_norm(x,y,self.x_tols['rtol'],self.x_tols['atol'])
 
     def maybe_build_roundtrip_state(
             self,

--- a/automcmc/selectors.py
+++ b/automcmc/selectors.py
@@ -30,14 +30,14 @@ class StepSizeSelector(ABC):
     def adapt_base_step_size(base_step_size, mean_step_size, n_samples_in_round):
         """
         Criterion for adapting the base step size after a round of sampling.
-        
+
         :param base_step_size: Previous base step size.
         :param mean_step_size: Average step size used in the round.
         :param n_samples_in_round: Length of the round.
         :return: An updated base step size.
         """
         return mean_step_size
-    
+
 #######################################
 # acceptance probability bracketing
 #######################################
@@ -45,7 +45,7 @@ class StepSizeSelector(ABC):
 class AcceptProbBracketingSelector(StepSizeSelector, metaclass=ABCMeta):
     """
     Class of selectors that adjust the step size by bracketing the acceptance
-    probability in a possibly randomized interval (Biron-Lattes et al. 2024, 
+    probability in a possibly randomized interval (Biron-Lattes et al. 2024,
     Liu et al. 2025)
 
     :param max_n_iter: Maximum number of step size doubling/halvings.
@@ -55,7 +55,7 @@ class AcceptProbBracketingSelector(StepSizeSelector, metaclass=ABCMeta):
     """
 
     def __init__(
-            self, 
+            self,
             max_n_iter=14, # 2**14~1.6e4 => step size changes +/- 4 orders of mag
             bounds_sampler=_draw_log_unif_bounds
         ):
@@ -70,7 +70,7 @@ class AcceptProbBracketingSelector(StepSizeSelector, metaclass=ABCMeta):
         :return: Random instance of the parameters used by the selector.
         """
         return self.bounds_sampler(rng_key)
-    
+
     @staticmethod
     @abstractmethod
     def should_grow(parameters, log_diff):
@@ -111,7 +111,7 @@ class AsymmetricSelector(AcceptProbBracketingSelector):
     @staticmethod
     def should_shrink(bounds, log_diff):
         return jnp.logical_or(
-            jnp.logical_not(lax.is_finite(log_diff)), 
+            jnp.logical_not(lax.is_finite(log_diff)),
             log_diff < bounds[0]
         )
 
@@ -120,7 +120,7 @@ def make_deterministic_bounds_sampler(p_lo, p_hi):
     fixed_bounds = jnp.log(jnp.array([p_lo, p_hi]))
     return (lambda _: fixed_bounds)
 
-def DeterministicAsymmetricSelector(p_lo=0.001, p_hi=0.999, *args, **kwargs):
+def DeterministicAsymmetricSelector(p_lo=0.0001, p_hi=0.9999, *args, **kwargs):
     """
     Asymmetric selector with fixed deterministic endpoints.
 
@@ -151,7 +151,7 @@ class SymmetricSelector(AcceptProbBracketingSelector):
             lax.abs(log_diff) + bounds[0] > 0
         )
 
-def DeterministicSymmetricSelector(p_lo=0.001, p_hi=0.999, *args, **kwargs):
+def DeterministicSymmetricSelector(p_lo=0.0001, p_hi=0.9999, *args, **kwargs):
     """
     Symmetric selector with fixed deterministic endpoints.
 
@@ -168,11 +168,11 @@ def DeterministicSymmetricSelector(p_lo=0.001, p_hi=0.999, *args, **kwargs):
 
 class FixedStepSizeSelector(AcceptProbBracketingSelector):
     """
-    A dummy selector that never adjusts the step size. 
+    A dummy selector that never adjusts the step size.
     """
     def __init__(self):
         super().__init__(
-            max_n_iter = 0, 
+            max_n_iter = 0,
             bounds_sampler = make_deterministic_bounds_sampler(0.4, 0.6) # bounds are irrelevant
         )
 
@@ -183,7 +183,7 @@ class FixedStepSizeSelector(AcceptProbBracketingSelector):
     @staticmethod
     def should_shrink(bounds, log_diff):
         return False
-    
+
     @staticmethod
     def adapt_base_step_size(base_step_size, mean_step_size, n_samples_in_round):
         return base_step_size
@@ -218,16 +218,16 @@ DEBUG_EXECUTOR = False
 def gen_alter_step_size_cond_fun(pred_fun, max_n_iter):
     def alter_step_size_cond_fun(args):
         (
-            state, 
-            exponent, 
-            next_log_joint, 
+            state,
+            exponent,
+            next_log_joint,
             init_log_joint,
-            selector_params, 
+            selector_params,
             precond_state
         ) = args
 
         # `numerically_safe_diff` is used to avoid corner cases where the step
-        # size is 0 already but, because of extreme nonlinearities, the 
+        # size is 0 already but, because of extreme nonlinearities, the
         # potential at this fictituous "next" point gives a log_joint that is
         # exactly equal to the next float of `init_log_joint`
         log_diff = utils.numerically_safe_diff(init_log_joint,next_log_joint)
@@ -242,11 +242,11 @@ def gen_alter_step_size_cond_fun(pred_fun, max_n_iter):
 def gen_alter_step_size_body_fun(kernel, direction):
     def alter_step_size_body_fun(args):
         (
-            state, 
-            exponent, 
-            next_log_joint, 
+            state,
+            exponent,
+            next_log_joint,
             init_log_joint,
-            selector_params, 
+            selector_params,
             precond_state
         ) = args
         exponent = exponent + direction
@@ -261,9 +261,9 @@ def gen_alter_step_size_body_fun(kernel, direction):
         # maybe print debug info
         if DEBUG_EXECUTOR:
             jax.debug.print(
-                "dir: {d: d}: base: {bs:.8f} + exp: {e: d} = eps: {s:.8f} | (L0, L1, DL, NDL): ({l0: .2f},{l1: .2f},{dl: .2f},{ndl: .2f}) | bounds: ({a:.3f},{b:.3f})", 
+                "dir: {d: d}: base: {bs:.8f} + exp: {e: d} = eps: {s:.8f} | (L0, L1, DL, NDL): ({l0: .2f},{l1: .2f},{dl: .2f},{ndl: .2f}) | bounds: ({a:.3f},{b:.3f})",
                 ordered=True,
-                d=direction, 
+                d=direction,
                 bs=state.base_step_size,
                 e=exponent,
                 s=eps,
@@ -282,11 +282,11 @@ def gen_alter_step_size_body_fun(kernel, direction):
             # )
 
         return (
-            state, 
-            exponent, 
-            next_log_joint, 
+            state,
+            exponent,
+            next_log_joint,
             init_log_joint,
-            selector_params, 
+            selector_params,
             precond_state
         )
 
@@ -313,45 +313,45 @@ def gen_target_acc_prob_executor(kernel):
     grow_step_size_body_fun = gen_alter_step_size_body_fun(kernel, 1)
 
     def shrink_step_size(
-            state, 
-            selector_params, 
-            next_log_joint, 
-            init_log_joint, 
+            state,
+            selector_params,
+            next_log_joint,
+            init_log_joint,
             precond_state
         ):
         exponent = 0
         state, exponent, *_ = lax.while_loop(
             shrink_step_size_cond_fun,
             shrink_step_size_body_fun,
-            (state, exponent, next_log_joint, init_log_joint, 
+            (state, exponent, next_log_joint, init_log_joint,
                 selector_params, precond_state)
         )
         return state, exponent
 
     def grow_step_size(
-            state, 
-            selector_params, 
-            next_log_joint, 
-            init_log_joint, 
+            state,
+            selector_params,
+            next_log_joint,
+            init_log_joint,
             precond_state
         ):
-        exponent = 0        
+        exponent = 0
         state, exponent, *_ = lax.while_loop(
             grow_step_size_cond_fun,
             grow_step_size_body_fun,
-            (state, exponent, next_log_joint, init_log_joint, 
+            (state, exponent, next_log_joint, init_log_joint,
                 selector_params, precond_state)
         )
 
-        # deduct 1 step to avoid cliffs, but only if we actually entered the 
+        # deduct 1 step to avoid cliffs, but only if we actually entered the
         # loop and didn't go over the max number of iterations
         exponent = jnp.where(
             jnp.logical_and(exponent > 0, exponent < selector.max_n_iter),
-            exponent-1, 
+            exponent-1,
             exponent
         )
         return state, exponent
-    
+
     def auto_step_size_fn(state, selector_params, precond_state):
         init_log_joint = state.log_joint # Note: assumes the log joint value is up to date!
         next_state = kernel.update_log_joint(
@@ -362,7 +362,7 @@ def gen_target_acc_prob_executor(kernel):
         state = copy_state_extras(next_state, state) # update state's stats and rng_key
 
         # try shrinking (no-op if selector decides not to shrink)
-        # note: we call the output of this `state` because it should equal the 
+        # note: we call the output of this `state` because it should equal the
         # initial state except for extra fields -- stats, rng_key -- which we
         # want to update
         state, shrink_exponent = shrink_step_size(
@@ -376,7 +376,7 @@ def gen_target_acc_prob_executor(kernel):
 
         # can add the two since one of them must be zero
         return state, shrink_exponent + grow_exponent
-    
+
     return auto_step_size_fn
 
 #######################################
@@ -384,7 +384,7 @@ def gen_target_acc_prob_executor(kernel):
 #######################################
 
 def gen_max_ejd_executor(kernel):
-    
+
     def expected_jump_dist(eps, state, precond_state):
         # take the step
         next_state = kernel.update_log_joint(
@@ -425,7 +425,7 @@ def gen_max_ejd_executor(kernel):
             return (e, old_ejd, new_ejd, state, precond_state)
 
         return cond_fn, body_fn
-    
+
     inc_cond_fn, inc_body_fn = gen_optim_ejd_funcs(kernel, 1)
     dec_cond_fn, dec_body_fn = gen_optim_ejd_funcs(kernel, -1)
 
@@ -437,13 +437,13 @@ def gen_max_ejd_executor(kernel):
         state, inc_eps_ejd = expected_jump_dist(inc_eps, state, precond_state)
         dec_eps = kernel.step_size(state.base_step_size, -1)
         state, dec_eps_ejd = expected_jump_dist(dec_eps, state, precond_state)
-        
+
         # check which direction gives the best improvement
         # Note: KEY IMPLEMENTATION DETAIL
-        # argmax defaults to first elem when they are all equal. In particular, 
-        # when all(all_ejd==0), the decrease direction is selected. This is 
-        # intentional! Doing this allows the algorithm to decrease the step 
-        # size since it is clearly too agressive.  
+        # argmax defaults to first elem when they are all equal. In particular,
+        # when all(all_ejd==0), the decrease direction is selected. This is
+        # intentional! Doing this allows the algorithm to decrease the step
+        # size since it is clearly too agressive.
         all_ejd = jnp.array([dec_eps_ejd,base_eps_ejd,inc_eps_ejd])
         imax = all_ejd.argmax()
         new_ejd = all_ejd[imax]
@@ -477,5 +477,5 @@ def gen_max_ejd_executor(kernel):
             jax.debug.print("final: e={}", exponent, ordered=True)
 
         return state, exponent
-    
+
     return auto_step_size_fn

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -70,6 +70,12 @@ def n_warmup_to_adapt_rounds(n_warmup):
 # numerical utils
 ###############################################################################
 
+def newton_default_tol(x):
+    return 10*jnp.finfo(x.dtype).eps
+
+def newton_fn_value_err(val):
+    return jnp.abs(val).max()
+
 def newton(
         f: Callable[[ArrayLike], jax.Array],
         x0: ArrayLike,
@@ -83,11 +89,11 @@ def newton(
     :param Callable[[ArrayLike], jax.Array] f: target function
     :param ArrayLike x0: initial guess
     :param Optional[float] tol: convergence tolerance, defaults to None, in
-        which case the `sqrt(eps)` value is used depending on the types of
+        which case an adequate value is chosen depending on the float type of
         the inputs.
     :param int max_iter: maximum number of Newton steps, defaults to 100
     :param str mode: one of `("direct", "gmres")`. The default `"gmres"` uses
-        the iterative GMRES solver together with `jax.jvp` to avoid ever 
+        the iterative GMRES solver together with `jax.jvp` to avoid ever
         forming the full Jacobian. When `mode="direct"`, the full Jacobian is
         formed and the update direction is obtained via a linear solve.
     :return tuple: A tuple of
@@ -102,9 +108,9 @@ def newton(
     dim = len(x0)
     val0 = f(x0)
     assert len(val0) == dim
-    err0 = jnp.abs(val0).max()
+    err0 = newton_fn_value_err(val0)
     if tol is None:
-        tol = jnp.sqrt(jnp.finfo(err0.dtype).eps)
+        tol = newton_default_tol(err0)
 
     def cond_fn(carry):
         x, n, val, err, d_err = carry
@@ -136,13 +142,13 @@ def newton(
             )[0]
         else:
             raise ValueError(f"Unknown mode `{mode}`")
-        
+
         # return updated carry
         x += dx
         val = f(x)
-        err = jnp.abs(val).max()
+        err = newton_fn_value_err(val)
         return (x, n, val, err, err-err0)
-    
+
     # run loop and return full carry for diagnostics plus flag
     carry = jax.lax.while_loop(cond_fn, body_fn, (x0, 0, val0, err0, err0))
     return (*carry, carry[3]<tol)

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -71,7 +71,7 @@ def n_warmup_to_adapt_rounds(n_warmup):
 ###############################################################################
 
 def newton_default_tol(x):
-    return 10*jnp.finfo(x.dtype).eps
+    return 100*jnp.finfo(x.dtype).eps
 
 def newton_fn_value_err(val):
     return jnp.abs(val).max()

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -130,9 +130,10 @@ def newton(
         #   J_f(x) dx = -f(x) ==> x' = x + dx
         if mode == "direct":
             # form full Jacobian and use a direct solver
-            dx = jnp.linalg.solve(jax.jacobian(f)(x), -val0)
+            # use fwd mode since the system is square
+            dx = jnp.linalg.solve(jax.jacfwd(f)(x), -val0)
         elif mode == "gmres":
-            # use GMRES with Jacobian-vector products
+            # use GMRES with Jacobian-vector products (i.e. fwd mode autodiff)
             # Note: we use this solver in a setting where dim^2 storage is ok,
             # and the absolute worst case time complexity O(dim^3) is tolerable
             # every now and then. Therefore, we avoid restarting

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -70,8 +70,33 @@ def n_warmup_to_adapt_rounds(n_warmup):
 # numerical utils
 ###############################################################################
 
-def newton_default_tol(x):
-    return 100*jnp.finfo(x.dtype).eps
+def close_in_norm(
+        x: ArrayLike,
+        y: ArrayLike,
+        rtol: ArrayLike,
+        atol: ArrayLike
+    ) -> jax.Array:
+    """
+    Check closeness of two arrays by comparing the norm of their difference to
+    the maximum of their individual norms
+
+    :param ArrayLike x: first array to compare.
+    :param ArrayLike y: second array to compare.
+    :param ArrayLike rtol: relative tolerance.
+    :param ArrayLike atol: absolute tolerance
+    :return jax.Array: `True` if close.
+    """
+    diff_norm = jnp.linalg.norm(x-y)
+    x_norm = jnp.linalg.norm(x)
+    y_norm = jnp.linalg.norm(y)
+    return diff_norm < jnp.maximum(atol, rtol*jnp.maximum(x_norm, y_norm))
+
+def newton_default_tol(x: ArrayLike) -> jax.Array:
+    # for float64, eps^(0.32) ~ 1e-5 which is the std tol use in most packages
+    # we use eps^0.4 for a slightly tighter requirement.
+    # This is then increased as log(n) because we focus on max-error, which
+    # scales logarithmically in the iid case (assuming mgf exists)
+    return jnp.maximum(1.0,jnp.log(x.size))*(jnp.finfo(x.dtype).eps**0.4)
 
 def newton_fn_value_err(val):
     return jnp.abs(val).max()
@@ -81,7 +106,7 @@ def newton(
         x0: ArrayLike,
         tol: Optional[float] = None,
         max_iter: int = 100,
-        mode: str = "gmres"
+        mode: str = "direct"
     ) -> tuple:
     """
     A Newton root solver.
@@ -92,10 +117,13 @@ def newton(
         which case an adequate value is chosen depending on the float type of
         the inputs.
     :param int max_iter: maximum number of Newton steps, defaults to 100
-    :param str mode: one of `("direct", "gmres")`. The default `"gmres"` uses
+    :param str mode: one of `("direct", "gmres")`. The option `"gmres"` uses
         the iterative GMRES solver together with :func:`jax.linearize` to avoid
         forming the full Jacobian. When `mode="direct"`, the full Jacobian is
-        formed and the update direction is obtained via a linear solve.
+        formed and the update direction is obtained via a linear solve. The
+        latter is the default choice, as this solver is intended for use in a
+        setting where :math:`O(d^2)` storage is acceptable, and direct solvers
+        should always be preferred when feasible.
     :return tuple: A tuple of
 
         * `x`: root

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -73,12 +73,31 @@ def n_warmup_to_adapt_rounds(n_warmup):
 def newton(
         f: Callable[[ArrayLike], jax.Array],
         x0: ArrayLike,
-        tol: Optional[ArrayLike] = None,
+        tol: Optional[float] = None,
         max_iter: int = 100,
-        mode: str = "direct"
-    ) -> tuple[jax.Array, ...]:
+        mode: str = "gmres"
+    ) -> tuple:
     """
-    Root finding using Newton's method.
+    A Newton root solver.
+
+    :param Callable[[ArrayLike], jax.Array] f: target function
+    :param ArrayLike x0: initial guess
+    :param Optional[float] tol: convergence tolerance, defaults to None, in
+        which case the `sqrt(eps)` value is used depending on the types of
+        the inputs.
+    :param int max_iter: maximum number of Newton steps, defaults to 100
+    :param str mode: one of `("direct", "gmres")`. The default `"gmres"` uses
+        the iterative GMRES solver together with `jax.jvp` to avoid ever 
+        forming the full Jacobian. When `mode="direct"`, the full Jacobian is
+        formed and the update direction is obtained via a linear solve.
+    :return tuple: A tuple of
+
+        * `x`: root
+        * `n`: number of iterations
+        * `val`: function value at the root
+        * `err`: maximum absolute value of `val`
+        * `d_err`: change in `err` in the last iteration
+        * `flag`: true if `err<tol` (i.e., success)
     """
     dim = len(x0)
     val0 = f(x0)
@@ -106,7 +125,7 @@ def newton(
         if mode == "direct":
             # form full Jacobian and use a direct solver
             dx = jnp.linalg.solve(jax.jacobian(f)(x), -val0)
-        elif mode == "iterative":
+        elif mode == "gmres":
             # use GMRES with Jacobian-vector products
             # Note: we use this solver in a setting where dim^2 storage is ok,
             # and the absolute worst case time complexity O(dim^3) is tolerable
@@ -124,5 +143,6 @@ def newton(
         err = jnp.abs(val).max()
         return (x, n, val, err, err-err0)
     
-    # run loop and return full carry for diagnostics
-    return jax.lax.while_loop(cond_fn, body_fn, (x0, 0, val0, err0, err0))
+    # run loop and return full carry for diagnostics plus flag
+    carry = jax.lax.while_loop(cond_fn, body_fn, (x0, 0, val0, err0, err0))
+    return (*carry, carry[3]<tol)

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -1,7 +1,10 @@
+from typing import Callable, Optional
+
 import jax
 from jax import lax
 from jax import numpy as jnp
 from jax.experimental import checkify
+from jax.typing import ArrayLike
 
 ###############################################################################
 # basic utilities
@@ -62,3 +65,64 @@ def current_round(n_samples):
 
 def n_warmup_to_adapt_rounds(n_warmup):
     return ceil_log2(n_warmup + 2) - 1
+
+###############################################################################
+# numerical utils
+###############################################################################
+
+def newton(
+        f: Callable[[ArrayLike], jax.Array],
+        x0: ArrayLike,
+        tol: Optional[ArrayLike] = None,
+        max_iter: int = 100,
+        mode: str = "direct"
+    ) -> tuple[jax.Array, ...]:
+    """
+    Root finding using Newton's method.
+    """
+    dim = len(x0)
+    val0 = f(x0)
+    assert len(val0) == dim
+    err0 = jnp.abs(val0).max()
+    if tol is None:
+        tol = jnp.sqrt(jnp.finfo(err0.dtype).eps)
+
+    def cond_fn(carry):
+        x, n, val, err, d_err = carry
+        return jnp.logical_and(
+            n < max_iter,                        # still have budget to go
+            jnp.logical_and(
+                err >= tol,                      # error still high
+                jnp.logical_or(n<3, d_err < tol) # after 3rd round, error is not increasing significantly
+            )
+        )
+
+    def body_fn(carry):
+        x, n, val0, err0, _ = carry
+        n += 1
+
+        # solve for Newton's update
+        #   J_f(x) dx = -f(x) ==> x' = x + dx
+        if mode == "direct":
+            # form full Jacobian and use a direct solver
+            dx = jnp.linalg.solve(jax.jacobian(f)(x), -val0)
+        elif mode == "iterative":
+            # use GMRES with Jacobian-vector products
+            # Note: we use this solver in a setting where dim^2 storage is ok,
+            # and the absolute worst case time complexity O(dim^3) is tolerable
+            # every now and then. Therefore, we avoid restarting
+            jvp = lambda v: jax.jvp(f, (x,), (v,))[1]
+            dx = jax.scipy.sparse.linalg.gmres(
+                jvp, -val0, tol=tol, restart=dim
+            )[0]
+        else:
+            raise ValueError(f"Unknown mode `{mode}`")
+        
+        # return updated carry
+        x += dx
+        val = f(x)
+        err = jnp.abs(val).max()
+        return (x, n, val, err, err-err0)
+    
+    # run loop and return full carry for diagnostics
+    return jax.lax.while_loop(cond_fn, body_fn, (x0, 0, val0, err0, err0))

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -93,7 +93,7 @@ def newton(
         the inputs.
     :param int max_iter: maximum number of Newton steps, defaults to 100
     :param str mode: one of `("direct", "gmres")`. The default `"gmres"` uses
-        the iterative GMRES solver together with `jax.jvp` to avoid ever
+        the iterative GMRES solver together with :func:`jax.linearize` to avoid
         forming the full Jacobian. When `mode="direct"`, the full Jacobian is
         formed and the update direction is obtained via a linear solve.
     :return tuple: A tuple of
@@ -136,7 +136,7 @@ def newton(
             # Note: we use this solver in a setting where dim^2 storage is ok,
             # and the absolute worst case time complexity O(dim^3) is tolerable
             # every now and then. Therefore, we avoid restarting
-            jvp = lambda v: jax.jvp(f, (x,), (v,))[1]
+            jvp = jax.linearize(f, x)[1] # faster than e.g. lambda v: jax.jvp(f, (x,), (v,))[1]
             dx = jax.scipy.sparse.linalg.gmres(
                 jvp, -val0, tol=tol, restart=dim
             )[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "jax",
+    "jax<=0.9.2",
     "numpyro",
     "optax",
     "tqdm"

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -60,7 +60,7 @@ class TestConstrained(unittest.TestCase):
     def test_constrained_involution(self):
         potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
         rng_key = jax.random.key(1)
-        n_dim = 9
+        n_dim = 121
         step_size = 0.5/jnp.sqrt(n_dim) # step should prob decrease with dim (assume same rate as std rwmh)
         constraint_fn_types= {
             'circle': lambda x: (x*x).sum(keepdims=True)-1,
@@ -68,87 +68,86 @@ class TestConstrained(unittest.TestCase):
         }
         n_reps = 3
         for constraint_fn_type, constraint_fn in constraint_fn_types.items():
-            for mode in ("direct","gmres"):
-                for n_rep in range(n_reps):
-                    with self.subTest(
-                        mode=mode,
-                        n_rep=n_rep,
-                        constraint_fn_type=constraint_fn_type
-                    ):
-                        # test initialization to feasible set
-                        kernel = constrained.AutoConstrainedRWMH(
-                            potential_fn=potential_fn,
-                            constraint_fn=constraint_fn,
-                            solver_options={'mode': mode},                        )
-                        (
-                            rng_key,
-                            randn_key,
-                            init_key,
-                            refresh_key
-                        ) = jax.random.split(rng_key, 4)
-                        init_params = jax.random.normal(randn_key, (n_dim,))
-                        state = kernel.init(init_key, 0, init_params, (), {})
-                        tol = kernel.solver_options['tol']
-                        self.assertTrue(state.idiosyncratic.is_satisfied)
-                        self.assertLess(
-                            utils.newton_fn_value_err(constraint_fn(state.x)), tol
-                        )
+            for n_rep in range(n_reps):
+                with self.subTest(
+                    constraint_fn_type=constraint_fn_type,
+                    n_rep=n_rep,
+                ):
+                    # test initialization to feasible set
+                    kernel = constrained.AutoConstrainedRWMH(
+                        potential_fn=potential_fn,
+                        constraint_fn=constraint_fn,
+                    )
+                    (
+                        rng_key,
+                        randn_key,
+                        init_key,
+                        refresh_key
+                    ) = jax.random.split(rng_key, 4)
+                    init_params = jax.random.normal(randn_key, (n_dim,))
+                    state = kernel.init(init_key, 0, init_params, (), {})
+                    tol = kernel.solver_options['tol']
+                    self.assertTrue(state.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(constraint_fn(state.x)), tol
+                    )
 
-                        # test log joint and velocity refreshment
-                        preconditioner = kernel.preconditioner
-                        precond_state = preconditioner.maybe_alter_precond_state(
-                            state.base_precond_state, 0
-                        )
-                        state = kernel.update_log_joint(
-                            kernel.refresh_aux_vars(refresh_key, state, precond_state),
-                            precond_state
-                        )
-                        self.assertAlmostEqual(
-                            state.log_prior,
-                            state.idiosyncratic.log_abs_det - potential_fn(state.x),
-                            delta=tol
-                        )
+                    # test log joint and velocity refreshment
+                    preconditioner = kernel.preconditioner
+                    precond_state = preconditioner.maybe_alter_precond_state(
+                        state.base_precond_state, 0
+                    )
+                    state = kernel.update_log_joint(
+                        kernel.refresh_aux_vars(refresh_key, state, precond_state),
+                        precond_state
+                    )
+                    self.assertAlmostEqual(
+                        state.log_prior,
+                        state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                        delta=tol
+                    )
 
-                        # test involutive property
-                        state_half = kernel.involution_main(
-                            step_size, state, precond_state
-                        )
-                        self.assertTrue(state_half.idiosyncratic.is_satisfied)
-                        self.assertLess(
-                            utils.newton_fn_value_err(constraint_fn(state_half.x)),
-                            tol
-                        )
-                        self.assertFalse(kernel.close_in_ambient_space(
-                                state_half.x, state.x
-                        ))
-                        self.assertAlmostEqual(
-                            # due to nature of this problem, velocities are also
-                            # rotating around, and therefore its density (std
-                            # normal) should be preserved
-                            kernel.kinetic_energy(state_half, precond_state),
-                            kernel.kinetic_energy(state, precond_state),
-                            delta = n_dim*tol
-                        )
-                        state_one = kernel.involution_aux(state_half)
-                        state_onehalf = kernel.involution_main(
-                            step_size, state_one, precond_state
-                        )
-                        self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
-                        self.assertLess(
-                            utils.newton_fn_value_err(
-                                constraint_fn(state_onehalf.x)
-                            ),
-                            tol
-                        )
-                        state_two = kernel.involution_aux(state_onehalf)
-                        self.assertTrue(kernel.close_in_ambient_space(
-                            state_two.x, state.x
-                        ))
-                        self.assertTrue(
-                            kernel.close_in_ambient_space(
-                                state_two.p_flat, state.p_flat
-                            ),
-                        )
+                    # test involutive property
+                    state_half = kernel.involution_main(
+                        step_size, state, precond_state
+                    )
+                    self.assertTrue(state_half.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(constraint_fn(state_half.x)),
+                        tol
+                    )
+                    self.assertFalse(kernel.close_in_ambient_space(
+                            state_half.x, state.x
+                    ))
+                    self.assertAlmostEqual(
+                        # due to nature of this problem, velocities are also
+                        # rotating around, and therefore its density (std
+                        # normal) should be preserved
+                        kernel.kinetic_energy(state_half, precond_state),
+                        kernel.kinetic_energy(state, precond_state),
+                        delta = n_dim*tol
+                    )
+                    state_one = kernel.involution_aux(state_half)
+                    state_onehalf = kernel.involution_main(
+                        step_size, state_one, precond_state
+                    )
+                    self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(
+                            constraint_fn(state_onehalf.x)
+                        ),
+                        tol
+                    )
+                    state_two = kernel.involution_aux(state_onehalf)
+                    self.assertTrue(
+                        kernel.close_in_ambient_space(state_two.x, state.x),
+                        f"|diff|/|x0| = {jnp.linalg.norm(state_two.x- state.x)/jnp.linalg.norm(state.x)}"
+                    )
+                    self.assertTrue(
+                        kernel.close_in_ambient_space(
+                            state_two.p_flat, state.p_flat
+                        ),
+                    )
 
     def test_sampling_torus(self):
         # T^2 torus embedded in R^3
@@ -246,36 +245,37 @@ class TestConstrained(unittest.TestCase):
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
         ):
-            rng_key, mcmc_key = jax.random.split(rng_key)
-            kernel = constrained.AutoConstrainedRWMH(
-                potential_fn=testutils.cone_potential,
-                constraint_fn=testutils.cone_constraint,
-                solver_options={'mode': 'direct'},
-                init_base_step_size = 0.9, # same as in paper
-                selector = sel
-            )
-            mcmc = MCMC(
-                kernel,
-                num_warmup=n_warm,
-                num_samples=n_keep,
-                thinning=thinning,
-                progress_bar=False
-            )
-            mcmc.run(
-                mcmc_key, init_params=init_params, extra_fields=extra_fields
-            )
-            log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-            self.assertLess(
-                jnp.abs(log_abs_det+jnp.log(2)/2).max(), 1e-5 # check it matches the known constant
-            )
+            with self.subTest(sel=sel):
+                rng_key, mcmc_key = jax.random.split(rng_key)
+                kernel = constrained.AutoConstrainedRWMH(
+                    potential_fn=testutils.cone_potential,
+                    constraint_fn=testutils.cone_constraint,
+                    solver_options={'mode': 'direct'},
+                    init_base_step_size = 0.9, # same as in paper
+                    selector = sel
+                )
+                mcmc = MCMC(
+                    kernel,
+                    num_warmup=n_warm,
+                    num_samples=n_keep,
+                    thinning=thinning,
+                    progress_bar=False
+                )
+                mcmc.run(
+                    mcmc_key, init_params=init_params, extra_fields=extra_fields
+                )
+                log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+                self.assertLess(
+                    jnp.abs(log_abs_det+jnp.log(2)/2).max(), 1e-5 # check it matches the known constant
+                )
 
-            # ks tests
-            xs,ys,zs = mcmc.get_samples().T
-            xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
-            z_cdf = np.square
-            self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
-            self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
-            self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
+                # ks tests
+                xs,ys,zs = mcmc.get_samples().T
+                xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
+                z_cdf = np.square
+                self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
+                self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
+                self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -135,19 +135,15 @@ class TestConstrained(unittest.TestCase):
         # Note: this example satisfies JJ^T = constant, which for the
         # particular choices of (R=1,r=1/2) used here give JJ^T = 1.
         # Hence, the Lebesgue measure induces the uniform dist on the surface
-        # This is why we can compare to the results in the paper, which
-        # focus on the uniform dist on the torus
 
         # define problem params
         R, r = 1.0, 0.5
         rng_key = jax.random.key(1)
 
         # Setup 1-sample KS tests on known (phi, theta) marginals
-        theta_cdf = partial(stats.uniform.cdf, scale=2*np.pi)
-        phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
-        phi_cdf = np.vectorize(
-            lambda q: integrate.quad(phi_pdf_fn, np.zeros_like(q), q)[0]
-        )
+        theta_cdf_fn = partial(stats.uniform.cdf, scale=2*np.pi)
+        # phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
+        phi_cdf_fn = lambda q: (q+(r/R)*jnp.sin(q)) / (2*jnp.pi)
 
         # check problem functions are correct
         constraint_fn = partial(testutils.torus_constraint, R, r)
@@ -174,6 +170,7 @@ class TestConstrained(unittest.TestCase):
         mode = "direct"
         potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
         n_warm, n_keep = utils.split_n_rounds(15)
+        thinning=32 # %ESS ~ 1/32
         init_params = jnp.ones(3) # init outside level set on purpose
         extra_fields = ('idiosyncratic.log_abs_det',)
         for sel in (
@@ -192,12 +189,12 @@ class TestConstrained(unittest.TestCase):
                 kernel,
                 num_warmup=n_warm,
                 num_samples=n_keep,
-                thinning=32, # %ESS ~ 1/32
+                thinning=thinning,
                 progress_bar=False
             )
             mcmc.run(mcmc_key,init_params=init_params, extra_fields=extra_fields)
             log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-            assert jnp.abs(log_abs_det).max() < 1e-5 # check that they are all ~0
+            self.assertLess(jnp.abs(log_abs_det).max(), 1e-5) # check that they are all ~0
             samples = mcmc.get_samples()
             self.assertLessEqual(
                 utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),
@@ -208,9 +205,49 @@ class TestConstrained(unittest.TestCase):
             self.assertAlmostEqual(phi.mean(), jnp.pi, delta=0.15)
 
             # KS tests
-            self.assertAlmostEqual(phi_cdf(2*np.pi), 1.0)
-            self.assertGreater(stats.ks_1samp(theta, theta_cdf).pvalue, 0.01)
-            self.assertGreater(stats.ks_1samp(phi, phi_cdf).pvalue, 0.01)
+            self.assertGreater(stats.ks_1samp(theta, theta_cdf_fn).pvalue, 0.01)
+            self.assertGreater(stats.ks_1samp(phi, phi_cdf_fn).pvalue, 0.01)
+
+
+    def test_sampling_cone(self):
+        # cone embedded in R^3
+        # Example 2 in Zappa & Holmes-Cerfon (2018)
+        # Note: this example satisfies JJ^T = constant, so the Lebesgue measure
+        # induces the uniform dist on the surface
+
+        # mcmc sampling
+        init_params=jnp.full((3,), 0.5) # init in interior of cone
+        n_warm, n_keep = utils.split_n_rounds(15)
+        thinning=16 # %ESS ~ 1/16
+        mcmc_key = jax.random.key(32)
+        extra_fields = ('idiosyncratic.log_abs_det',)
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=testutils.cone_potential,
+            constraint_fn=testutils.cone_constraint,
+            solver_options={'mode': 'direct'},
+            init_base_step_size = 0.9, # same as in paper
+            selector = selectors.FixedStepSizeSelector()
+        )
+        mcmc = MCMC(
+            kernel,
+            num_warmup=n_warm,
+            num_samples=n_keep,
+            thinning=thinning,
+            progress_bar=False
+        )
+        mcmc.run(mcmc_key,init_params=init_params,extra_fields=extra_fields)
+        log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+        self.assertLess(
+            jnp.abs(log_abs_det+jnp.log(2)/2).max(), 1e-5 # check it matches the known constant
+        )
+        xs,ys,zs = mcmc.get_samples().T
+
+        # ks tests
+        xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
+        z_cdf = np.square
+        self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
+        self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
+        self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -47,92 +47,91 @@ class TestConstrained(unittest.TestCase):
         # constrain to unit circle
         potential_fn = lambda x: 0.5*jnp.dot(x,x)
         constraint_fn = lambda x: (x*x).sum(keepdims=True)-1
-        rng_key = jax.random.key(1)
+        rng_key, randn_key = jax.random.split(jax.random.key(1))
         n_dim = 30
+        step_size = 0.5/jnp.sqrt(n_dim) # step should prob decrease with dim (assume same rate as std rwmh)
+        all_init_params = {
+            "randn": jax.random.normal(randn_key,n_dim),
+            "ones": jnp.ones(n_dim),
+            "arange":jnp.arange(n_dim,dtype=float)
+        }
+        for init_params_type, init_params in all_init_params.items():
+            for mode in ("direct","gmres"):
+                with self.subTest(mode=mode,init_params_type=init_params_type):
+                    kernel = constrained.AutoConstrainedRWMH(
+                        potential_fn=potential_fn,
+                        constraint_fn=constraint_fn,
+                        solver_options={'mode': mode}
+                    )
 
-        for mode in ("direct","gmres"):
-            with self.subTest(mode=mode):
-                kernel = constrained.AutoConstrainedRWMH(
-                    potential_fn=potential_fn,
-                    constraint_fn=constraint_fn,
-                    solver_options={'mode': mode}
-                )
+                    # test initialization to feasible set
+                    rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
+                    state = kernel.init(init_key, 0, init_params, (), {})
+                    tol = kernel.solver_options['tol']
+                    self.assertTrue(state.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(constraint_fn(state.x)), tol
+                    )
 
-                # test initialization to feasible set
-                rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
-                init_params = jnp.ones(n_dim)
-                state = kernel.init(init_key, 0, init_params, (), {})
-                tol = kernel.solver_options['tol']
-                self.assertLess(
-                    utils.newton_fn_value_err(constraint_fn(state.x)), tol
-                )
-                self.assertTrue(state.idiosyncratic.is_satisfied)
-                self.assertTrue(kernel.close_in_ambient_space(
-                    # due to the characteristics of the problem, solution must
-                    # coincide with the orthogonal projection
-                    state.x, init_params / jnp.sqrt(n_dim)
-                ))
+                    # test log joint and velocity refreshment
+                    precond_state = kernel.preconditioner.maybe_alter_precond_state(
+                        state.base_precond_state, 0
+                    )
+                    state = kernel.update_log_joint(
+                        kernel.refresh_aux_vars(refresh_key, state, precond_state),
+                        precond_state
+                    )
+                    self.assertAlmostEqual(
+                        state.log_prior,
+                        state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                        delta=tol
+                    )
+                    self.assertAlmostEqual(
+                        jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
+                        0,
+                        delta=tol
+                    )
 
-                # test log joint and velocity refreshment
-                precond_state = kernel.preconditioner.maybe_alter_precond_state(
-                    state.base_precond_state, 0
-                )
-                state = kernel.update_log_joint(
-                    kernel.refresh_aux_vars(refresh_key, state, precond_state),
-                    precond_state
-                )
-                self.assertAlmostEqual(
-                    state.log_prior,
-                    state.idiosyncratic.log_abs_det - potential_fn(state.x),
-                    delta=tol
-                )
-                self.assertAlmostEqual(
-                    jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
-                    0,
-                    delta=tol
-                )
-
-                # test involutive property
-                step_size = jax.lax.rsqrt(n_dim+0.0) # step should prob decrease with dim (assume same rate as std rwmh)
-                state_half = kernel.involution_main(
-                    step_size, state, precond_state
-                )
-                self.assertLess(
-                    utils.newton_fn_value_err(constraint_fn(state_half.x)), tol
-                )
-                self.assertTrue(state_half.idiosyncratic.is_satisfied)
-                self.assertFalse(kernel.close_in_ambient_space(
-                        state_half.x, state.x
-                ))
-                self.assertAlmostEqual(
-                    jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
-                    0,
-                    delta=10*tol
-                )
-                self.assertAlmostEqual(
-                    # due to nature of this problem, velocities are also
-                    # rotating around, and therefore its density (std
-                    # normal) should be preserved
-                    kernel.kinetic_energy(state_half, precond_state),
-                    kernel.kinetic_energy(state, precond_state),
-                    delta = n_dim*tol
-                )
-                state_one = kernel.involution_aux(state_half)
-                state_onehalf = kernel.involution_main(
-                    step_size, state_one, precond_state
-                )
-                self.assertLess(
-                    utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
-                    tol
-                )
-                self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
-                state_two = kernel.involution_aux(state_onehalf)
-                self.assertTrue(kernel.close_in_ambient_space(
-                    state_two.x, state.x
-                ))
-                self.assertTrue(kernel.close_in_ambient_space(
-                    state_two.p_flat, state.p_flat
-                ))
+                    # test involutive property
+                    state_half = kernel.involution_main(
+                        step_size, state, precond_state
+                    )
+                    self.assertTrue(state_half.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(constraint_fn(state_half.x)), tol
+                    )
+                    self.assertFalse(kernel.close_in_ambient_space(
+                            state_half.x, state.x
+                    ))
+                    self.assertAlmostEqual(
+                        jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
+                        0,
+                        delta=tol
+                    )
+                    self.assertAlmostEqual(
+                        # due to nature of this problem, velocities are also
+                        # rotating around, and therefore its density (std
+                        # normal) should be preserved
+                        kernel.kinetic_energy(state_half, precond_state),
+                        kernel.kinetic_energy(state, precond_state),
+                        delta = n_dim*tol
+                    )
+                    state_one = kernel.involution_aux(state_half)
+                    state_onehalf = kernel.involution_main(
+                        step_size, state_one, precond_state
+                    )
+                    self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
+                    self.assertLess(
+                        utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
+                        tol
+                    )
+                    state_two = kernel.involution_aux(state_onehalf)
+                    self.assertTrue(kernel.close_in_ambient_space(
+                        state_two.x, state.x
+                    ))
+                    self.assertTrue(kernel.close_in_ambient_space(
+                        state_two.p_flat, state.p_flat
+                    ))
 
     def test_sampling_torus(self):
         # T^2 torus embedded in R^3

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -2,9 +2,16 @@ import unittest
 import jax
 from jax import numpy as jnp
 
-from automcmc import constrained,utils
+from automcmc import constrained,utils,preconditioning
 
 class TestConstrained(unittest.TestCase):
+
+    def test_invalid_inputs(self):
+        with self.assertRaises(AssertionError):
+            constrained.AutoConstrainedRWMH(
+                potential_fn=lambda x: 0.0,
+                preconditioner=preconditioning.FixedDensePreconditioner(),
+            )
 
     def test_Jacobian_algebra(self):
         m = 6

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -2,28 +2,114 @@ import unittest
 import jax
 from jax import numpy as jnp
 
-from automcmc import constrained
+from automcmc import constrained,utils
 
 class TestConstrained(unittest.TestCase):
 
-    def test_jac_op(self):
+    def test_Jacobian_algebra(self):
         m = 6
         n = 145
         J_key, v_key = jax.random.split(jax.random.key(1),2)
         v = jax.random.normal(v_key, (n,))
         J = jax.random.normal(J_key, (m,n))
         tol = jnp.sqrt(jnp.finfo(J.dtype).eps)
-        jop = constrained.JacobianOperator(J)
-        self.assertAlmostEqual(1, jnp.linalg.cond(jop.Q),delta=tol)
+        cs = constrained.make_constraint_state(True,J) # err is irrelevant here
+        self.assertAlmostEqual(1, jnp.linalg.cond(cs.Q),delta=tol)
         self.assertGreater(jnp.linalg.cond(J.T), 1.1)
-        self.assertTrue(jnp.abs(jop.Q.T@jop.Q - jnp.identity(m)).max() < tol)
+        self.assertTrue(jnp.abs(cs.Q.T@cs.Q - jnp.identity(m)).max() < tol)
         self.assertTrue(jnp.isclose(
-            jop.log_abs_det,
+            cs.log_abs_det,
             -0.5*jnp.log(jnp.abs(jnp.linalg.det(jnp.inner(J,J)))),
             rtol = 0.01
         ))
-        _,PTv = jop.proj_normal_tangent(v)
+        _,PTv = constrained.proj_normal_tangent(cs, v)
         self.assertTrue(jnp.abs(J@PTv).max() < tol) # PTv should be orthogonal to every row of J
+
+    def test_involution(self):
+        # std normal prior on R^n
+        # constrain to unit circle
+        potential_fn = lambda x: 0.5*jnp.dot(x,x)
+        constraint_fn = lambda x: (x*x).sum(keepdims=True)-1
+        rng_key = jax.random.key(1)
+        n_dim = 30
+
+        for mode in ("direct","gmres"):
+            kernel = constrained.AutoConstrainedRWMH(
+                potential_fn=potential_fn,
+                constraint_fn=constraint_fn,
+                solver_options={
+                    'tol': 10*jnp.finfo(jnp.float32).eps,
+                    'mode': mode
+                }
+            )
+
+            # test initialization to feasible set
+            rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
+            init_params = jnp.ones(n_dim)
+            state = kernel.init(init_key, 0, init_params, (), {})
+            tol = kernel.solver_options['tol']
+            self.assertTrue(
+                utils.newton_fn_value_err(constraint_fn(state.x)) < tol and
+                state.idiosyncratic.is_satisfied
+            )
+            self.assertTrue(jnp.allclose(
+                # due to the characteristics of the problem, solution must
+                # coincide with the orthogonal projection
+                state.x, init_params / jnp.sqrt(n_dim), rtol=0.01
+            ))
+
+            # test log joint and velocity refreshment
+            precond_state = kernel.preconditioner.maybe_alter_precond_state(
+                state.base_precond_state, 0
+            )
+            state = kernel.update_log_joint(
+                kernel.refresh_aux_vars(refresh_key, state, precond_state), precond_state
+            )
+            self.assertAlmostEqual(
+                state.log_prior,
+                state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                delta=tol
+            )
+            self.assertAlmostEqual(
+                jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
+                0,
+                delta=tol
+            )
+
+            # test involutive property
+            step_size = jax.lax.rsqrt(n_dim+0.0) # step should prob decrease with dim (assume same rate as std rwmh)
+            state_half = kernel.involution_main(step_size, state, precond_state)
+            self.assertTrue(
+                utils.newton_fn_value_err(constraint_fn(state_half.x)) < tol and
+                state_half.idiosyncratic.is_satisfied
+            )
+            self.assertFalse(jnp.allclose(state_half.x, state.x, atol=10*tol, rtol=0.01))
+            self.assertAlmostEqual(
+                jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
+                0,
+                delta=tol
+            )
+            self.assertAlmostEqual(
+                # due to nature of this problem, velocities are also rotating around, and
+                # therefore its density (std normal) should be preserved
+                kernel.kinetic_energy(state_half, precond_state),
+                kernel.kinetic_energy(state, precond_state),
+                delta = n_dim*tol
+            )
+            state_one = kernel.involution_aux(state_half)
+            state_onehalf = kernel.involution_main(step_size, state_one, precond_state)
+            self.assertTrue(
+                utils.newton_fn_value_err(constraint_fn(state_onehalf.x)) < tol and
+                state_onehalf.idiosyncratic.is_satisfied
+            )
+            state_two = kernel.involution_aux(state_onehalf)
+            self.assertTrue(
+                jnp.allclose(state_two.x, state.x, atol=10*tol, rtol=0.01)
+            )
+            self.assertTrue(
+                jnp.allclose(state_two.p_flat, state.p_flat, atol=10*tol, rtol=0.01)
+            )
+
 
 
 if __name__ == '__main__':

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -278,6 +278,47 @@ class TestConstrained(unittest.TestCase):
                 self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
 
 
+    def test_sample_orthonormal(self):
+        # matrices with orthonormal rows
+        # Example 3 in Zappa & Holmes-Cerfon (2018)
+        # TODO: show that JJ^T is indeed constant (empirically true so far)
+        constraint_fn=testutils.orthonormal_constraint
+        potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
+        d = 11
+        n_dim = d*d
+
+        # mcmc sampling
+        rng_key, init_key = jax.random.split(jax.random.key(53))
+        init_params=jax.random.normal(init_key, (n_dim,)) # init in interior of cone
+        n_warm, n_keep = utils.split_n_rounds(16)
+        thinning=2**6 # %ESS ~ 1/64
+        extra_fields = ('idiosyncratic.log_abs_det',)
+        rng_key, mcmc_key = jax.random.split(rng_key)
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=potential_fn,
+            constraint_fn=constraint_fn,
+            solver_options={'mode': 'direct'},
+            init_base_step_size = 0.28, # in paper
+            selector = selectors.FixedStepSizeSelector()
+        )
+        mcmc = MCMC(
+            kernel,
+            num_warmup=n_warm,
+            num_samples=n_keep,
+            thinning=thinning,
+            progress_bar=False
+        )
+        mcmc.run(
+            mcmc_key, init_params=init_params, extra_fields=extra_fields
+        )
+        log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+        self.assertLess(log_abs_det.std(), 0.05)
+
+        # ks test for normality of traces of the matrices
+        traces = jax.vmap(lambda v: jnp.diag(v.reshape((d,d))).sum())(mcmc.get_samples())
+        self.assertGreater(stats.ks_1samp(traces, stats.norm.cdf).pvalue, 0.01)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -135,7 +135,9 @@ class TestConstrained(unittest.TestCase):
                         )
                         self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
                         self.assertLess(
-                            utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
+                            utils.newton_fn_value_err(
+                                constraint_fn(state_onehalf.x)
+                            ),
                             tol
                         )
                         state_two = kernel.involution_aux(state_onehalf)
@@ -143,10 +145,9 @@ class TestConstrained(unittest.TestCase):
                             state_two.x, state.x
                         ))
                         self.assertTrue(
-                            kernel.close_in_ambient_space(state_two.p_flat, state.p_flat),
-                            f"rel_error={
-                                jnp.linalg.norm(state_two.p_flat-state.p_flat)/jnp.linalg.norm(state.p_flat)
-                            }"
+                            kernel.close_in_ambient_space(
+                                state_two.p_flat, state.p_flat
+                            ),
                         )
 
     def test_sampling_torus(self):

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1,8 +1,16 @@
+from tests import utils as testutils
+
+from functools import partial
 import unittest
+
+import numpy as np
+from scipy import stats, integrate
+
 import jax
 from jax import numpy as jnp
 
-from automcmc import constrained,utils,preconditioning
+from automcmc import constrained,utils,preconditioning,selectors
+from numpyro.infer import MCMC
 
 class TestConstrained(unittest.TestCase):
 
@@ -118,6 +126,59 @@ class TestConstrained(unittest.TestCase):
             self.assertTrue(kernel.close_in_ambient_space(
                 state_two.p_flat, state.p_flat
             ))
+
+    def test_sampling_torus(self):
+        # uniform dist on T^2 torus embedded in R^3
+        # Example 1 in Zappa & Holmes-Cerfon (2018)
+        # Run 1-sample KS tests on known (phi, theta) marginals
+
+        # define problem params
+        R, r = 1.0, 0.5
+        rng_key = jax.random.key(1)
+
+        # check problem functions are correct
+        constraint_fn = partial(testutils.torus_constraint, R, r)
+        self.assertGreater(
+            jnp.abs(constraint_fn(jnp.zeros(3))[0]), 0.1
+        )
+        param_fn = partial(testutils.torus_param, R, r)
+        inv_param_fn = partial(testutils.inv_torus_param, R, r)
+        rng_key, angles_key, mcmc_key = jax.random.split(rng_key, 3)
+        theta, phi = 2*jnp.pi*jax.random.uniform(angles_key, (2,2**10))
+        theta2, phi2 = inv_param_fn(*param_fn(theta, phi))
+        self.assertTrue(jnp.allclose(theta, theta2))
+        self.assertTrue(jnp.allclose(phi, phi2))
+        self.assertLess(
+            jnp.abs(jax.vmap(constraint_fn,in_axes=(1,))(param_fn(theta, phi))).max(),
+            1e-6
+        )
+
+        # mcmc sampling
+        # use thinning to approximate independent sampling so KS test
+        # assumption is "less broken"
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=lambda x: jnp.zeros_like(x,shape=()), # uniform
+            constraint_fn=constraint_fn,
+            solver_options={'mode': 'direct'},
+            # use fixed step size
+            # same as in paper, gives ~ 68% acc prob
+            init_base_step_size = 0.5,
+            selector = selectors.FixedStepSizeSelector()
+        )
+        mcmc = MCMC(kernel,num_warmup=1024,num_samples=2**15,thinning=32)
+        mcmc.run(mcmc_key, init_params=jnp.ones(3))
+        samples = mcmc.get_samples()
+        theta, phi = inv_param_fn(*samples.T)
+
+        # KS tests
+        theta_cdf = partial(stats.uniform.cdf, scale=2*np.pi)
+        phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
+        phi_cdf = np.vectorize(
+            lambda q: integrate.quad(phi_pdf_fn, np.zeros_like(q), q)[0]
+        )
+        self.assertAlmostEqual(phi_cdf(2*np.pi), 1.0)
+        self.assertGreater(stats.ks_1samp(theta, theta_cdf).pvalue, 0.01)
+        self.assertGreater(stats.ks_1samp(phi, phi_cdf).pvalue, 0.01)
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -58,85 +58,96 @@ class TestConstrained(unittest.TestCase):
 
 
     def test_constrained_involution(self):
-        # std normal prior on R^n
-        # constrain to unit circle
-        potential_fn = lambda x: 0.5*jnp.dot(x,x)
-        constraint_fn = lambda x: (x*x).sum(keepdims=True)-1
-        rng_key, randn_key = jax.random.split(jax.random.key(1))
-        n_dim = 30
+        potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
+        rng_key = jax.random.key(1)
+        n_dim = 9
         step_size = 0.5/jnp.sqrt(n_dim) # step should prob decrease with dim (assume same rate as std rwmh)
-        all_init_params = {
-            "randn": jax.random.normal(randn_key,n_dim),
-            "ones": jnp.ones(n_dim),
-            "arange":jnp.arange(n_dim,dtype=float)
+        constraint_fn_types= {
+            'circle': lambda x: (x*x).sum(keepdims=True)-1,
+            'orthonormal': testutils.orthonormal_constraint
         }
-        for init_params_type, init_params in all_init_params.items():
+        n_reps = 3
+        for constraint_fn_type, constraint_fn in constraint_fn_types.items():
             for mode in ("direct","gmres"):
-                with self.subTest(mode=mode,init_params_type=init_params_type):
-                    kernel = constrained.AutoConstrainedRWMH(
-                        potential_fn=potential_fn,
-                        constraint_fn=constraint_fn,
-                        solver_options={'mode': mode}
-                    )
+                for n_rep in range(n_reps):
+                    with self.subTest(
+                        mode=mode,
+                        n_rep=n_rep,
+                        constraint_fn_type=constraint_fn_type
+                    ):
+                        # test initialization to feasible set
+                        kernel = constrained.AutoConstrainedRWMH(
+                            potential_fn=potential_fn,
+                            constraint_fn=constraint_fn,
+                            solver_options={'mode': mode},                        )
+                        (
+                            rng_key,
+                            randn_key,
+                            init_key,
+                            refresh_key
+                        ) = jax.random.split(rng_key, 4)
+                        init_params = jax.random.normal(randn_key, (n_dim,))
+                        state = kernel.init(init_key, 0, init_params, (), {})
+                        tol = kernel.solver_options['tol']
+                        self.assertTrue(state.idiosyncratic.is_satisfied)
+                        self.assertLess(
+                            utils.newton_fn_value_err(constraint_fn(state.x)), tol
+                        )
 
-                    # test initialization to feasible set
-                    rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
-                    state = kernel.init(init_key, 0, init_params, (), {})
-                    tol = kernel.solver_options['tol']
-                    self.assertTrue(state.idiosyncratic.is_satisfied)
-                    self.assertLess(
-                        utils.newton_fn_value_err(constraint_fn(state.x)), tol
-                    )
+                        # test log joint and velocity refreshment
+                        preconditioner = kernel.preconditioner
+                        precond_state = preconditioner.maybe_alter_precond_state(
+                            state.base_precond_state, 0
+                        )
+                        state = kernel.update_log_joint(
+                            kernel.refresh_aux_vars(refresh_key, state, precond_state),
+                            precond_state
+                        )
+                        self.assertAlmostEqual(
+                            state.log_prior,
+                            state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                            delta=tol
+                        )
 
-                    # test log joint and velocity refreshment
-                    precond_state = kernel.preconditioner.maybe_alter_precond_state(
-                        state.base_precond_state, 0
-                    )
-                    state = kernel.update_log_joint(
-                        kernel.refresh_aux_vars(refresh_key, state, precond_state),
-                        precond_state
-                    )
-                    self.assertAlmostEqual(
-                        state.log_prior,
-                        state.idiosyncratic.log_abs_det - potential_fn(state.x),
-                        delta=tol
-                    )
-
-                    # test involutive property
-                    state_half = kernel.involution_main(
-                        step_size, state, precond_state
-                    )
-                    self.assertTrue(state_half.idiosyncratic.is_satisfied)
-                    self.assertLess(
-                        utils.newton_fn_value_err(constraint_fn(state_half.x)), tol
-                    )
-                    self.assertFalse(kernel.close_in_ambient_space(
-                            state_half.x, state.x
-                    ))
-                    self.assertAlmostEqual(
-                        # due to nature of this problem, velocities are also
-                        # rotating around, and therefore its density (std
-                        # normal) should be preserved
-                        kernel.kinetic_energy(state_half, precond_state),
-                        kernel.kinetic_energy(state, precond_state),
-                        delta = n_dim*tol
-                    )
-                    state_one = kernel.involution_aux(state_half)
-                    state_onehalf = kernel.involution_main(
-                        step_size, state_one, precond_state
-                    )
-                    self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
-                    self.assertLess(
-                        utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
-                        tol
-                    )
-                    state_two = kernel.involution_aux(state_onehalf)
-                    self.assertTrue(kernel.close_in_ambient_space(
-                        state_two.x, state.x
-                    ))
-                    self.assertTrue(kernel.close_in_ambient_space(
-                        state_two.p_flat, state.p_flat
-                    ))
+                        # test involutive property
+                        state_half = kernel.involution_main(
+                            step_size, state, precond_state
+                        )
+                        self.assertTrue(state_half.idiosyncratic.is_satisfied)
+                        self.assertLess(
+                            utils.newton_fn_value_err(constraint_fn(state_half.x)),
+                            tol
+                        )
+                        self.assertFalse(kernel.close_in_ambient_space(
+                                state_half.x, state.x
+                        ))
+                        self.assertAlmostEqual(
+                            # due to nature of this problem, velocities are also
+                            # rotating around, and therefore its density (std
+                            # normal) should be preserved
+                            kernel.kinetic_energy(state_half, precond_state),
+                            kernel.kinetic_energy(state, precond_state),
+                            delta = n_dim*tol
+                        )
+                        state_one = kernel.involution_aux(state_half)
+                        state_onehalf = kernel.involution_main(
+                            step_size, state_one, precond_state
+                        )
+                        self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
+                        self.assertLess(
+                            utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
+                            tol
+                        )
+                        state_two = kernel.involution_aux(state_onehalf)
+                        self.assertTrue(kernel.close_in_ambient_space(
+                            state_two.x, state.x
+                        ))
+                        self.assertTrue(
+                            kernel.close_in_ambient_space(state_two.p_flat, state.p_flat),
+                            f"rel_error={
+                                jnp.linalg.norm(state_two.p_flat-state.p_flat)/jnp.linalg.norm(state.p_flat)
+                            }"
+                        )
 
     def test_sampling_torus(self):
         # T^2 torus embedded in R^3

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -31,7 +31,9 @@ class TestConstrained(unittest.TestCase):
         cs = constrained.make_constraint_state(True,J) # err is irrelevant here
         self.assertAlmostEqual(1, jnp.linalg.cond(cs.Q),delta=tol)
         self.assertGreater(jnp.linalg.cond(J.T), 1.1)
-        self.assertTrue(jnp.abs(cs.Q.T@cs.Q - jnp.identity(m)).max() < tol)
+        self.assertLess(
+            utils.newton_fn_value_err(cs.Q.T@cs.Q - jnp.identity(m)), tol
+        )
         self.assertTrue(jnp.isclose(
             cs.log_abs_det,
             -0.5*jnp.log(jnp.abs(jnp.linalg.det(jnp.inner(J,J)))),
@@ -131,6 +133,11 @@ class TestConstrained(unittest.TestCase):
         # uniform dist on T^2 torus embedded in R^3
         # Example 1 in Zappa & Holmes-Cerfon (2018)
         # Run 1-sample KS tests on known (phi, theta) marginals
+        theta_cdf = partial(stats.uniform.cdf, scale=2*np.pi)
+        phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
+        phi_cdf = np.vectorize(
+            lambda q: integrate.quad(phi_pdf_fn, np.zeros_like(q), q)[0]
+        )
 
         # define problem params
         R, r = 1.0, 0.5
@@ -149,36 +156,52 @@ class TestConstrained(unittest.TestCase):
         self.assertTrue(jnp.allclose(theta, theta2))
         self.assertTrue(jnp.allclose(phi, phi2))
         self.assertLess(
-            jnp.abs(jax.vmap(constraint_fn,in_axes=(1,))(param_fn(theta, phi))).max(),
+            utils.newton_fn_value_err(
+                jax.vmap(constraint_fn,in_axes=(1,))(param_fn(theta, phi))
+            ),
             1e-6
         )
 
         # mcmc sampling
         # use thinning to approximate independent sampling so KS test
         # assumption is "less broken"
-        kernel = constrained.AutoConstrainedRWMH(
-            potential_fn=lambda x: jnp.zeros_like(x,shape=()), # uniform
-            constraint_fn=constraint_fn,
-            solver_options={'mode': 'direct'},
-            # use fixed step size
-            # same as in paper, gives ~ 68% acc prob
-            init_base_step_size = 0.5,
-            selector = selectors.FixedStepSizeSelector()
-        )
-        mcmc = MCMC(kernel,num_warmup=1024,num_samples=2**15,thinning=32)
-        mcmc.run(mcmc_key, init_params=jnp.ones(3))
-        samples = mcmc.get_samples()
-        theta, phi = inv_param_fn(*samples.T)
+        mode = "direct"
+        potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
+        n_warm, n_keep = utils.split_n_rounds(15)
+        init_params = jnp.ones(3) # init outside level set on purpose
+        for sel in (
+            selectors.FixedStepSizeSelector(),
+            selectors.DeterministicSymmetricSelector(),
+        ):
+            rng_key, mcmc_key = jax.random.split(rng_key)
+            kernel = constrained.AutoConstrainedRWMH(
+                potential_fn=potential_fn,
+                constraint_fn=constraint_fn,
+                solver_options={'mode': mode},
+                init_base_step_size = 0.5, # step used in paper
+                selector = sel
+            )
+            mcmc = MCMC(
+                kernel,
+                num_warmup=n_warm,
+                num_samples=n_keep,
+                thinning=32, # %ESS ~ 1/32
+                progress_bar=False
+            )
+            mcmc.run(mcmc_key,init_params=init_params)
+            samples = mcmc.get_samples()
+            self.assertLess(
+                utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),
+                kernel.solver_options['tol']
+            )
+            theta, phi = inv_param_fn(*samples.T)
+            self.assertAlmostEqual(theta.mean(), jnp.pi, delta=0.1)
+            self.assertAlmostEqual(phi.mean(), jnp.pi, delta=0.1)
 
-        # KS tests
-        theta_cdf = partial(stats.uniform.cdf, scale=2*np.pi)
-        phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
-        phi_cdf = np.vectorize(
-            lambda q: integrate.quad(phi_pdf_fn, np.zeros_like(q), q)[0]
-        )
-        self.assertAlmostEqual(phi_cdf(2*np.pi), 1.0)
-        self.assertGreater(stats.ks_1samp(theta, theta_cdf).pvalue, 0.01)
-        self.assertGreater(stats.ks_1samp(phi, phi_cdf).pvalue, 0.01)
+            # KS tests
+            self.assertAlmostEqual(phi_cdf(2*np.pi), 1.0)
+            self.assertGreater(stats.ks_1samp(theta, theta_cdf).pvalue, 0.01)
+            self.assertGreater(stats.ks_1samp(phi, phi_cdf).pvalue, 0.01)
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -216,38 +216,45 @@ class TestConstrained(unittest.TestCase):
         # induces the uniform dist on the surface
 
         # mcmc sampling
+        rng_key = jax.random.key(67534)
         init_params=jnp.full((3,), 0.5) # init in interior of cone
-        n_warm, n_keep = utils.split_n_rounds(15)
+        n_warm, n_keep = utils.split_n_rounds(14)
         thinning=16 # %ESS ~ 1/16
-        mcmc_key = jax.random.key(32)
         extra_fields = ('idiosyncratic.log_abs_det',)
-        kernel = constrained.AutoConstrainedRWMH(
-            potential_fn=testutils.cone_potential,
-            constraint_fn=testutils.cone_constraint,
-            solver_options={'mode': 'direct'},
-            init_base_step_size = 0.9, # same as in paper
-            selector = selectors.FixedStepSizeSelector()
-        )
-        mcmc = MCMC(
-            kernel,
-            num_warmup=n_warm,
-            num_samples=n_keep,
-            thinning=thinning,
-            progress_bar=False
-        )
-        mcmc.run(mcmc_key,init_params=init_params,extra_fields=extra_fields)
-        log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-        self.assertLess(
-            jnp.abs(log_abs_det+jnp.log(2)/2).max(), 1e-5 # check it matches the known constant
-        )
-        xs,ys,zs = mcmc.get_samples().T
+        for sel in (
+            selectors.FixedStepSizeSelector(),
+            selectors.DeterministicSymmetricSelector(),
+        ):
+            rng_key, mcmc_key = jax.random.split(rng_key)
+            kernel = constrained.AutoConstrainedRWMH(
+                potential_fn=testutils.cone_potential,
+                constraint_fn=testutils.cone_constraint,
+                solver_options={'mode': 'direct'},
+                init_base_step_size = 0.9, # same as in paper
+                selector = sel
+            )
+            mcmc = MCMC(
+                kernel,
+                num_warmup=n_warm,
+                num_samples=n_keep,
+                thinning=thinning,
+                progress_bar=False
+            )
+            mcmc.run(
+                mcmc_key, init_params=init_params, extra_fields=extra_fields
+            )
+            log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+            self.assertLess(
+                jnp.abs(log_abs_det+jnp.log(2)/2).max(), 1e-5 # check it matches the known constant
+            )
 
-        # ks tests
-        xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
-        z_cdf = np.square
-        self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
-        self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
-        self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
+            # ks tests
+            xs,ys,zs = mcmc.get_samples().T
+            xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
+            z_cdf = np.square
+            self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
+            self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
+            self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -14,16 +14,16 @@ class TestConstrained(unittest.TestCase):
         J = jax.random.normal(J_key, (m,n))
         tol = jnp.sqrt(jnp.finfo(J.dtype).eps)
         jop = constrained.JacobianOperator(J)
-        assert jnp.isclose(1, jnp.linalg.cond(jop.Q))
-        assert jnp.linalg.cond(J.T) > 1.1
-        assert jnp.abs(jop.Q.T@jop.Q - jnp.identity(m)).max() < tol
-        assert jnp.isclose(
+        self.assertAlmostEqual(1, jnp.linalg.cond(jop.Q),delta=tol)
+        self.assertGreater(jnp.linalg.cond(J.T), 1.1)
+        self.assertTrue(jnp.abs(jop.Q.T@jop.Q - jnp.identity(m)).max() < tol)
+        self.assertTrue(jnp.isclose(
             jop.log_abs_det,
             -0.5*jnp.log(jnp.abs(jnp.linalg.det(jnp.inner(J,J)))),
             rtol = 0.01
-        )
+        ))
         _,PTv = jop.proj_normal_tangent(v)
-        assert jnp.abs(J@PTv).max() < tol # PTv should be orthogonal to every row of J
+        self.assertTrue(jnp.abs(J@PTv).max() < tol) # PTv should be orthogonal to every row of J
 
 
 if __name__ == '__main__':

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -195,8 +195,8 @@ class TestConstrained(unittest.TestCase):
                 kernel.solver_options['tol']
             )
             theta, phi = inv_param_fn(*samples.T)
-            self.assertAlmostEqual(theta.mean(), jnp.pi, delta=0.1)
-            self.assertAlmostEqual(phi.mean(), jnp.pi, delta=0.1)
+            self.assertAlmostEqual(theta.mean(), jnp.pi, delta=0.15)
+            self.assertAlmostEqual(phi.mean(), jnp.pi, delta=0.15)
 
             # KS tests
             self.assertAlmostEqual(phi_cdf(2*np.pi), 1.0)

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -4,7 +4,7 @@ from functools import partial
 import unittest
 
 import numpy as np
-from scipy import stats, integrate
+from scipy import stats
 
 import jax
 from jax import numpy as jnp
@@ -57,7 +57,6 @@ class TestConstrained(unittest.TestCase):
             )
 
 
-    # TODO: update test to new approach
     def test_constrained_involution(self):
         # std normal prior on R^n
         # constrain to unit circle

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -59,10 +59,10 @@ class TestConstrained(unittest.TestCase):
                 utils.newton_fn_value_err(constraint_fn(state.x)) < tol and
                 state.idiosyncratic.is_satisfied
             )
-            self.assertTrue(jnp.allclose(
+            self.assertTrue(kernel.close_in_ambient_space(
                 # due to the characteristics of the problem, solution must
                 # coincide with the orthogonal projection
-                state.x, init_params / jnp.sqrt(n_dim), rtol=0.01
+                state.x, init_params / jnp.sqrt(n_dim)
             ))
 
             # test log joint and velocity refreshment
@@ -90,11 +90,13 @@ class TestConstrained(unittest.TestCase):
                 utils.newton_fn_value_err(constraint_fn(state_half.x)) < tol and
                 state_half.idiosyncratic.is_satisfied
             )
-            self.assertFalse(jnp.allclose(state_half.x, state.x, atol=10*tol, rtol=0.01))
+            self.assertFalse(kernel.close_in_ambient_space(
+                    state_half.x, state.x
+            ))
             self.assertAlmostEqual(
                 jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
                 0,
-                delta=tol
+                delta=10*tol
             )
             self.assertAlmostEqual(
                 # due to nature of this problem, velocities are also rotating around, and
@@ -110,12 +112,12 @@ class TestConstrained(unittest.TestCase):
                 state_onehalf.idiosyncratic.is_satisfied
             )
             state_two = kernel.involution_aux(state_onehalf)
-            self.assertTrue(
-                jnp.allclose(state_two.x, state.x, atol=10*tol, rtol=0.01)
-            )
-            self.assertTrue(
-                jnp.allclose(state_two.p_flat, state.p_flat, atol=10*tol, rtol=0.01)
-            )
+            self.assertTrue(kernel.close_in_ambient_space(
+                state_two.x, state.x
+            ))
+            self.assertTrue(kernel.close_in_ambient_space(
+                state_two.p_flat, state.p_flat
+            ))
 
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -54,10 +54,7 @@ class TestConstrained(unittest.TestCase):
             kernel = constrained.AutoConstrainedRWMH(
                 potential_fn=potential_fn,
                 constraint_fn=constraint_fn,
-                solver_options={
-                    'tol': 10*jnp.finfo(jnp.float32).eps,
-                    'mode': mode
-                }
+                solver_options={'mode': mode}
             )
 
             # test initialization to feasible set

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -198,7 +198,7 @@ class TestConstrained(unittest.TestCase):
             )
             mcmc.run(mcmc_key,init_params=init_params, extra_fields=extra_fields)
             log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-            self.assertLess(jnp.abs(log_abs_det).max(), 1e-5) # check that they are all ~0
+            self.assertLess(jnp.abs(log_abs_det).max(), kernel.x_tols['atol']) # check that they are all ~0
             samples = mcmc.get_samples()
             self.assertLessEqual(
                 utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1,0 +1,30 @@
+import unittest
+import jax
+from jax import numpy as jnp
+
+from automcmc import constrained
+
+class TestConstrained(unittest.TestCase):
+
+    def test_jac_op(self):
+        m = 6
+        n = 145
+        J_key, v_key = jax.random.split(jax.random.key(1),2)
+        v = jax.random.normal(v_key, (n,))
+        J = jax.random.normal(J_key, (m,n))
+        tol = jnp.sqrt(jnp.finfo(J.dtype).eps)
+        jop = constrained.JacobianOperator(J)
+        assert jnp.isclose(1, jnp.linalg.cond(jop.Q))
+        assert jnp.linalg.cond(J.T) > 1.1
+        assert jnp.abs(jop.Q.T@jop.Q - jnp.identity(m)).max() < tol
+        assert jnp.isclose(
+            jop.log_abs_det,
+            -0.5*jnp.log(jnp.abs(jnp.linalg.det(jnp.inner(J,J)))),
+            rtol = 0.01
+        )
+        _,PTv = jop.proj_normal_tangent(v)
+        assert jnp.abs(J@PTv).max() < tol # PTv should be orthogonal to every row of J
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -21,27 +21,43 @@ class TestConstrained(unittest.TestCase):
                 preconditioner=preconditioning.FixedDensePreconditioner(),
             )
 
-    def test_Jacobian_algebra(self):
-        m = 6
-        n = 145
-        J_key, v_key = jax.random.split(jax.random.key(1),2)
-        v = jax.random.normal(v_key, (n,))
-        J = jax.random.normal(J_key, (m,n))
-        tol = jnp.sqrt(jnp.finfo(J.dtype).eps)
-        cs = constrained.make_constraint_state(True,J) # err is irrelevant here
-        self.assertAlmostEqual(1, jnp.linalg.cond(cs.Q),delta=tol)
-        self.assertGreater(jnp.linalg.cond(J.T), 1.1)
-        self.assertLess(
-            utils.newton_fn_value_err(cs.Q.T@cs.Q - jnp.identity(m)), tol
-        )
-        self.assertTrue(jnp.isclose(
-            cs.log_abs_det,
-            -0.5*jnp.log(jnp.abs(jnp.linalg.det(jnp.inner(J,J)))),
-            rtol = 0.01
-        ))
-        _,PTv = constrained.proj_normal_tangent(cs, v)
-        self.assertTrue(jnp.abs(J@PTv).max() < tol) # PTv should be orthogonal to every row of J
+    def test_proj_normal_tangent(self):
+        d = 3
+        n = d*d
+        n_sim = 10
+        rng_key = jax.random.key(1)
+        for _ in range(n_sim):
+            X = jnp.array(stats.ortho_group.rvs(dim=d,)) # iid sample SO(3)
+            constraint_fn = testutils.orthonormal_constraint
+            tol = utils.newton_default_tol(X)
+            cs = constrained.make_constraint_state(constraint_fn,X.flatten(),tol)
+            self.assertTrue(cs.is_satisfied)
+            m = cs.chol.shape[0]
+            self.assertEqual(m, d*(d+1)//2)
+            J = jax.jacobian(constraint_fn)(cs.x_base)
+            gram_mat = jnp.inner(J,J)
+            self.assertLess(
+                jnp.linalg.norm(gram_mat - jnp.inner(cs.chol,cs.chol)), tol
+            )
+            self.assertAlmostEqual(
+                cs.log_abs_det,
+                -0.5*jnp.log(jnp.abs(jnp.linalg.det(gram_mat))),
+                delta = 0.001
+            )
+            rng_key, v_key = jax.random.split(rng_key)
+            v = jax.random.normal(v_key, (n,))
+            PNv,PTv = constrained.proj_normal_tangent(constraint_fn,cs,v)
+            self.assertTrue(jnp.allclose(v, PNv+PTv))
+            jvp_val = jax.jvp(constraint_fn, (cs.x_base,), (PTv,))[-1] # PTv \perp to every row of Jac
+            self.assertLess(jnp.abs(jvp_val).max(), 0.01)
+            jvp_val_dumb = J@PTv
+            self.assertTrue(
+                jnp.allclose(jvp_val, jvp_val_dumb, atol=tol, rtol=0.01),
+                f"jvp_val={jvp_val} but J@PTv={jvp_val_dumb}"
+            )
 
+
+    # TODO: update test to new approach
     def test_constrained_involution(self):
         # std normal prior on R^n
         # constrain to unit circle
@@ -86,11 +102,6 @@ class TestConstrained(unittest.TestCase):
                         state.idiosyncratic.log_abs_det - potential_fn(state.x),
                         delta=tol
                     )
-                    self.assertAlmostEqual(
-                        jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
-                        0,
-                        delta=tol
-                    )
 
                     # test involutive property
                     state_half = kernel.involution_main(
@@ -103,11 +114,6 @@ class TestConstrained(unittest.TestCase):
                     self.assertFalse(kernel.close_in_ambient_space(
                             state_half.x, state.x
                     ))
-                    self.assertAlmostEqual(
-                        jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
-                        0,
-                        delta=tol
-                    )
                     self.assertAlmostEqual(
                         # due to nature of this problem, velocities are also
                         # rotating around, and therefore its density (std

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -190,7 +190,7 @@ class TestConstrained(unittest.TestCase):
             )
             mcmc.run(mcmc_key,init_params=init_params)
             samples = mcmc.get_samples()
-            self.assertLess(
+            self.assertLessEqual(
                 utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),
                 kernel.solver_options['tol']
             )

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -42,7 +42,7 @@ class TestConstrained(unittest.TestCase):
         _,PTv = constrained.proj_normal_tangent(cs, v)
         self.assertTrue(jnp.abs(J@PTv).max() < tol) # PTv should be orthogonal to every row of J
 
-    def test_involution(self):
+    def test_constrained_involution(self):
         # std normal prior on R^n
         # constrain to unit circle
         potential_fn = lambda x: 0.5*jnp.dot(x,x)
@@ -51,80 +51,88 @@ class TestConstrained(unittest.TestCase):
         n_dim = 30
 
         for mode in ("direct","gmres"):
-            kernel = constrained.AutoConstrainedRWMH(
-                potential_fn=potential_fn,
-                constraint_fn=constraint_fn,
-                solver_options={'mode': mode}
-            )
+            with self.subTest(mode=mode):
+                kernel = constrained.AutoConstrainedRWMH(
+                    potential_fn=potential_fn,
+                    constraint_fn=constraint_fn,
+                    solver_options={'mode': mode}
+                )
 
-            # test initialization to feasible set
-            rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
-            init_params = jnp.ones(n_dim)
-            state = kernel.init(init_key, 0, init_params, (), {})
-            tol = kernel.solver_options['tol']
-            self.assertTrue(
-                utils.newton_fn_value_err(constraint_fn(state.x)) < tol and
-                state.idiosyncratic.is_satisfied
-            )
-            self.assertTrue(kernel.close_in_ambient_space(
-                # due to the characteristics of the problem, solution must
-                # coincide with the orthogonal projection
-                state.x, init_params / jnp.sqrt(n_dim)
-            ))
+                # test initialization to feasible set
+                rng_key, init_key, refresh_key = jax.random.split(rng_key, 3)
+                init_params = jnp.ones(n_dim)
+                state = kernel.init(init_key, 0, init_params, (), {})
+                tol = kernel.solver_options['tol']
+                self.assertLess(
+                    utils.newton_fn_value_err(constraint_fn(state.x)), tol
+                )
+                self.assertTrue(state.idiosyncratic.is_satisfied)
+                self.assertTrue(kernel.close_in_ambient_space(
+                    # due to the characteristics of the problem, solution must
+                    # coincide with the orthogonal projection
+                    state.x, init_params / jnp.sqrt(n_dim)
+                ))
 
-            # test log joint and velocity refreshment
-            precond_state = kernel.preconditioner.maybe_alter_precond_state(
-                state.base_precond_state, 0
-            )
-            state = kernel.update_log_joint(
-                kernel.refresh_aux_vars(refresh_key, state, precond_state), precond_state
-            )
-            self.assertAlmostEqual(
-                state.log_prior,
-                state.idiosyncratic.log_abs_det - potential_fn(state.x),
-                delta=tol
-            )
-            self.assertAlmostEqual(
-                jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
-                0,
-                delta=tol
-            )
+                # test log joint and velocity refreshment
+                precond_state = kernel.preconditioner.maybe_alter_precond_state(
+                    state.base_precond_state, 0
+                )
+                state = kernel.update_log_joint(
+                    kernel.refresh_aux_vars(refresh_key, state, precond_state),
+                    precond_state
+                )
+                self.assertAlmostEqual(
+                    state.log_prior,
+                    state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                    delta=tol
+                )
+                self.assertAlmostEqual(
+                    jnp.abs(jnp.dot(state.p_flat,state.idiosyncratic.Q))[0],
+                    0,
+                    delta=tol
+                )
 
-            # test involutive property
-            step_size = jax.lax.rsqrt(n_dim+0.0) # step should prob decrease with dim (assume same rate as std rwmh)
-            state_half = kernel.involution_main(step_size, state, precond_state)
-            self.assertTrue(
-                utils.newton_fn_value_err(constraint_fn(state_half.x)) < tol and
-                state_half.idiosyncratic.is_satisfied
-            )
-            self.assertFalse(kernel.close_in_ambient_space(
-                    state_half.x, state.x
-            ))
-            self.assertAlmostEqual(
-                jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
-                0,
-                delta=10*tol
-            )
-            self.assertAlmostEqual(
-                # due to nature of this problem, velocities are also rotating around, and
-                # therefore its density (std normal) should be preserved
-                kernel.kinetic_energy(state_half, precond_state),
-                kernel.kinetic_energy(state, precond_state),
-                delta = n_dim*tol
-            )
-            state_one = kernel.involution_aux(state_half)
-            state_onehalf = kernel.involution_main(step_size, state_one, precond_state)
-            self.assertTrue(
-                utils.newton_fn_value_err(constraint_fn(state_onehalf.x)) < tol and
-                state_onehalf.idiosyncratic.is_satisfied
-            )
-            state_two = kernel.involution_aux(state_onehalf)
-            self.assertTrue(kernel.close_in_ambient_space(
-                state_two.x, state.x
-            ))
-            self.assertTrue(kernel.close_in_ambient_space(
-                state_two.p_flat, state.p_flat
-            ))
+                # test involutive property
+                step_size = jax.lax.rsqrt(n_dim+0.0) # step should prob decrease with dim (assume same rate as std rwmh)
+                state_half = kernel.involution_main(
+                    step_size, state, precond_state
+                )
+                self.assertLess(
+                    utils.newton_fn_value_err(constraint_fn(state_half.x)), tol
+                )
+                self.assertTrue(state_half.idiosyncratic.is_satisfied)
+                self.assertFalse(kernel.close_in_ambient_space(
+                        state_half.x, state.x
+                ))
+                self.assertAlmostEqual(
+                    jnp.abs(jnp.dot(state_half.p_flat,state_half.idiosyncratic.Q))[0],
+                    0,
+                    delta=10*tol
+                )
+                self.assertAlmostEqual(
+                    # due to nature of this problem, velocities are also
+                    # rotating around, and therefore its density (std
+                    # normal) should be preserved
+                    kernel.kinetic_energy(state_half, precond_state),
+                    kernel.kinetic_energy(state, precond_state),
+                    delta = n_dim*tol
+                )
+                state_one = kernel.involution_aux(state_half)
+                state_onehalf = kernel.involution_main(
+                    step_size, state_one, precond_state
+                )
+                self.assertLess(
+                    utils.newton_fn_value_err(constraint_fn(state_onehalf.x)),
+                    tol
+                )
+                self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
+                state_two = kernel.involution_aux(state_onehalf)
+                self.assertTrue(kernel.close_in_ambient_space(
+                    state_two.x, state.x
+                ))
+                self.assertTrue(kernel.close_in_ambient_space(
+                    state_two.p_flat, state.p_flat
+                ))
 
     def test_sampling_torus(self):
         # T^2 torus embedded in R^3

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -130,18 +130,24 @@ class TestConstrained(unittest.TestCase):
             ))
 
     def test_sampling_torus(self):
-        # uniform dist on T^2 torus embedded in R^3
+        # T^2 torus embedded in R^3
         # Example 1 in Zappa & Holmes-Cerfon (2018)
-        # Run 1-sample KS tests on known (phi, theta) marginals
+        # Note: this example satisfies JJ^T = constant, which for the
+        # particular choices of (R=1,r=1/2) used here give JJ^T = 1.
+        # Hence, the Lebesgue measure induces the uniform dist on the surface
+        # This is why we can compare to the results in the paper, which
+        # focus on the uniform dist on the torus
+
+        # define problem params
+        R, r = 1.0, 0.5
+        rng_key = jax.random.key(1)
+
+        # Setup 1-sample KS tests on known (phi, theta) marginals
         theta_cdf = partial(stats.uniform.cdf, scale=2*np.pi)
         phi_pdf_fn = lambda x: (1+(r/R)*np.cos(x)) / (2*np.pi)
         phi_cdf = np.vectorize(
             lambda q: integrate.quad(phi_pdf_fn, np.zeros_like(q), q)[0]
         )
-
-        # define problem params
-        R, r = 1.0, 0.5
-        rng_key = jax.random.key(1)
 
         # check problem functions are correct
         constraint_fn = partial(testutils.torus_constraint, R, r)
@@ -169,6 +175,7 @@ class TestConstrained(unittest.TestCase):
         potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
         n_warm, n_keep = utils.split_n_rounds(15)
         init_params = jnp.ones(3) # init outside level set on purpose
+        extra_fields = ('idiosyncratic.log_abs_det',)
         for sel in (
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
@@ -188,7 +195,9 @@ class TestConstrained(unittest.TestCase):
                 thinning=32, # %ESS ~ 1/32
                 progress_bar=False
             )
-            mcmc.run(mcmc_key,init_params=init_params)
+            mcmc.run(mcmc_key,init_params=init_params, extra_fields=extra_fields)
+            log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+            assert jnp.abs(log_abs_det).max() < 1e-5 # check that they are all ~0
             samples = mcmc.get_samples()
             self.assertLessEqual(
                 utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,23 +29,23 @@ class TestUtils(unittest.TestCase):
         for mode in ("direct", "gmres"):
             # nice initial point
             x0 = jnp.array([0.2, 0.3, 0.5])
-            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
-            self.assertTrue(flag)
+            x, n, val, err, d_err, is_satisfied = utils.newton(f, x0, mode=mode)
+            self.assertTrue(is_satisfied)
             self.assertLess(err, 1e-3)
             self.assertLess(d_err, 0)
             self.assertTrue(jnp.allclose(x, x_true, rtol=0.05))
 
             # unstable initial point => divergence
             x0 = jnp.array([ 0.36057416,  1.2849895 , -0.73873436])
-            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
-            self.assertFalse(flag)
+            x, n, val, err, d_err, is_satisfied = utils.newton(f, x0, mode=mode)
+            self.assertFalse(is_satisfied)
             self.assertEqual(n, 4) # divergence caught
             self.assertGreater(d_err, 0)
 
             # initial point with rank-deficient Jacobian => inf/nans at n=1
             x0 = jnp.zeros_like(x_true)
-            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
-            self.assertFalse(flag)
+            x, n, val, err, d_err, is_satisfied = utils.newton(f, x0, mode=mode)
+            self.assertFalse(is_satisfied)
             self.assertEqual(n, 1) # nans caught
             self.assertTrue(jnp.isnan(d_err)) # nans caught
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(n_rounds, utils.current_round(n_samples))
 
     def test_newton(self):
-        # example from 
+        # example from
         # https://github.com/jax-ml/jax/discussions/17975#discussion-5707669
         def f(x):
             x, y, z = x
@@ -31,7 +31,7 @@ class TestUtils(unittest.TestCase):
             x0 = jnp.array([0.2, 0.3, 0.5])
             x, n, val, err, d_err, is_satisfied = utils.newton(f, x0, mode=mode)
             self.assertTrue(is_satisfied)
-            self.assertLess(err, 1e-3)
+            self.assertLess(err, utils.newton_default_tol(x))
             self.assertLess(d_err, 0)
             self.assertTrue(jnp.allclose(x, x_true, rtol=0.05))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,10 +30,12 @@ class TestUtils(unittest.TestCase):
             # nice initial point
             x0 = jnp.array([0.2, 0.3, 0.5])
             x, n, val, err, d_err, is_satisfied = utils.newton(f, x0, mode=mode)
-            self.assertTrue(is_satisfied)
+            self.assertTrue(is_satisfied, f"{(n, val, err, d_err)}")
             self.assertLess(err, utils.newton_default_tol(x))
             self.assertLess(d_err, 0)
-            self.assertTrue(jnp.allclose(x, x_true, rtol=0.05))
+            self.assertTrue(
+                utils.close_in_norm(x, x_true, rtol=0.05, atol=0.0)
+            )
 
             # unstable initial point => divergence
             x0 = jnp.array([ 0.36057416,  1.2849895 , -0.73873436])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,23 +26,26 @@ class TestUtils(unittest.TestCase):
 
         x_true = jnp.ones(3)
 
-        for mode in ("direct", "iterative"):
+        for mode in ("direct", "gmres"):
             # nice initial point
             x0 = jnp.array([0.2, 0.3, 0.5])
-            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
+            self.assertTrue(flag)
             self.assertLess(err, 1e-3)
             self.assertLess(d_err, 0)
             self.assertTrue(jnp.allclose(x, x_true, rtol=0.05))
 
             # unstable initial point => divergence
             x0 = jnp.array([ 0.36057416,  1.2849895 , -0.73873436])
-            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
+            self.assertFalse(flag)
             self.assertEqual(n, 4) # divergence caught
             self.assertGreater(d_err, 0)
 
             # initial point with rank-deficient Jacobian => inf/nans at n=1
             x0 = jnp.zeros_like(x_true)
-            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            x, n, val, err, d_err, flag = utils.newton(f, x0, mode=mode)
+            self.assertFalse(flag)
             self.assertEqual(n, 1) # nans caught
             self.assertTrue(jnp.isnan(d_err)) # nans caught
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,38 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(n_samples, 2**(n_rounds+1)-2)
             self.assertEqual(n_rounds, utils.current_round(n_samples))
 
+    def test_newton(self):
+        # example from 
+        # https://github.com/jax-ml/jax/discussions/17975#discussion-5707669
+        def f(x):
+            x, y, z = x
+            f1 = x**2 + y**2 + z**2 - 3
+            f2 = x**2 + y**2 - z    - 1
+            f3 = x    + y    + z    - 3
+            return jnp.array([f1, f2, f3])
+
+        x_true = jnp.ones(3)
+
+        for mode in ("direct", "iterative"):
+            # nice initial point
+            x0 = jnp.array([0.2, 0.3, 0.5])
+            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            self.assertLess(err, 1e-3)
+            self.assertLess(d_err, 0)
+            self.assertTrue(jnp.allclose(x, x_true, rtol=0.05))
+
+            # unstable initial point => divergence
+            x0 = jnp.array([ 0.36057416,  1.2849895 , -0.73873436])
+            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            self.assertEqual(n, 4) # divergence caught
+            self.assertGreater(d_err, 0)
+
+            # initial point with rank-deficient Jacobian => inf/nans at n=1
+            x0 = jnp.zeros_like(x_true)
+            x, n, val, err, d_err = utils.newton(f, x0, mode=mode)
+            self.assertEqual(n, 1) # nans caught
+            self.assertTrue(jnp.isnan(d_err)) # nans caught
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,9 @@
+import math
+
 import numpy
+
 import jax.numpy as jnp
+
 import numpyro
 import numpyro.distributions as dist
 
@@ -69,6 +73,19 @@ def make_eight_schools():
 #######################################
 # constrained problems
 #######################################
+
+# orthonormal rows constraint
+def orthonormal_constraint(x):
+    n = len(x)
+    d = math.isqrt(n)
+    assert d*d == n
+    X = x.reshape((d,d))
+    G = jnp.inner(X,X)
+    triu_inds = jnp.triu_indices(d)
+    G_triu = G[triu_inds[0],triu_inds[1]]
+    I_triu = jnp.identity(d)[triu_inds[0],triu_inds[1]]
+    return G_triu - I_triu
+
 
 ####### T^2 torus embedded in R^3 #####
 # Example 1 in Zappa & Holmes-Cerfon (2018)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,7 +70,7 @@ def make_eight_schools():
 # constrained problems
 #######################################
 
-# T^2 torus embedded in R^3
+####### T^2 torus embedded in R^3 #####
 # Example 1 in Zappa & Holmes-Cerfon (2018)
 #   F(x,y,z)=(R - sqrt{x^2+y^2})^2 + z^2 - r^2
 #   dF/dx = 2x(R - sqrt{x^2+y^2})/sqrt{x^2+y^2} = 2x(R/sqrt{x^2+y^2} - 1)
@@ -99,6 +99,38 @@ def inv_torus_param(R, r, x, y, z):
     d = jnp.hypot(x,y) - R
     phi = arctan2pi(z, d)
     return (theta, phi)
+
+###### cone embedded in R^3 #####
+# Example 2 in Zappa & Holmes-Cerfon (2018)
+# inequality constraints passed through pontential fn
+#   F(x,y,z) = z - sqrt(x^2 + y^2)
+#   dF/dx = x(x^2 + y^2)^{-1/2}
+#   dF/dy = y(x^2 + y^2)^{-1/2}
+#   dF/dz =  1
+#    JJ^T = 1 + x^2(x^2 + y^2)^{-1} + y^2(x^2 + y^2)^{-1}
+#      = 1 + (x^2 + y^2)(x^2 + y^2)^{-1}
+#      = 1 + 1
+#      = 2
+#   |JJ^T|^{-1/2} = 2^{-1/2} => log(|JJ^T|^{-1/2}) = -0.5log(2)
+# It follows that the ambient uniform induces the uniform distribution on each
+# level set (i.e., each cone)
+# Note: this wouldn't be the case if we used the alternative function
+#   G(x,y,z) = z^2 - x^2 + y^2
+# even though G^{-1}({0})=F^{-1}({0})! This is because the general equality is
+#
+#   for all r: G^{-1}({r})=F^{-1}({r^2})
+# Nevertheless, the total integral int dr int_cone(r) must end up being the
+# same since the LHS int_{R^3} f(x) dx is invariant to the choice of F,G.
+def cone_constraint(x):
+    return jnp.array([x[-1] - jnp.linalg.norm(x[:-1])])
+    # return jnp.array([x[-1]*x[-1] - jnp.square(x[:-1]).sum()])
+
+def cone_potential(x):
+    return jnp.where(
+        jnp.logical_and(jnp.square(x[:-1]).sum()<=1, x[-1] >= 0),
+        jnp.zeros_like(x, shape=()),
+        jnp.inf,
+    )
 
 ###############################################################################
 # diagnostics

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,8 +70,17 @@ def make_eight_schools():
 # constrained problems
 #######################################
 
-# uniform dist on T^2 torus embedded in R^3
+# T^2 torus embedded in R^3
 # Example 1 in Zappa & Holmes-Cerfon (2018)
+#   F(x,y,z)=(R - sqrt{x^2+y^2})^2 + z^2 - r^2
+#   dF/dx = 2x(R - sqrt{x^2+y^2})/sqrt{x^2+y^2} = 2x(R/sqrt{x^2+y^2} - 1)
+#   dF/dy = 2y(R/sqrt{x^2+y^2} - 1) // symmetry
+#   dF/dz = 2z
+# => JJ^T = 4[x^2+y^2](R/sqrt{x^2+y^2} - 1)^2 + 4z^2
+#   = 4(R - sqrt{x^2+y^2})^2 + 4z^2
+#   = 4[F(x,y,z)+r^2]
+# So when F(x,y,z)=0 and also r=1/2, we have
+#   JJ^T = 4/4 = 1 => |JJ^T|^{-1/2} = 1 => log(|JJ^T|^{-1/2}) = 0
 def torus_constraint(R, r, x):
     return jnp.array([
         jnp.square(R - jnp.linalg.norm(x[:-1])) + x[-1]*x[-1] - r*r

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -82,8 +82,10 @@ def orthonormal_constraint(x):
     X = x.reshape((d,d))
     G = jnp.inner(X,X)
     triu_inds = jnp.triu_indices(d)
-    G_triu = G[*triu_inds]
-    I_triu = jnp.identity(d)[*triu_inds]
+    # NB: G[*tuple] doesn't work in Python 3.10
+    # https://peps.python.org/pep-0646/#change-1-star-expressions-in-indexes
+    G_triu = G[triu_inds[0],triu_inds[1]]
+    I_triu = jnp.identity(d)[triu_inds[0],triu_inds[1]]
     return G_triu - I_triu
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,10 @@ import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 
+###############################################################################
+# toy examples
+###############################################################################
+
 def gaussian_potential(x):
     return ((x - 2) ** 2).sum()
 
@@ -31,8 +35,8 @@ def toy_unid(n_flips, n_heads=None):
 #
 # Ref: Biron-Lattes, Campbell, & Bouchard-Côté (2024)
 def toy_conjugate_normal(
-        d = jnp.int32(3), 
-        m = jnp.float32(2.), 
+        d = jnp.int32(3),
+        m = jnp.float32(2.),
         sigma0 = jnp.float32(2.)
     ):
     def model(sigma0, y):
@@ -61,6 +65,35 @@ def make_eight_schools():
     model_args = (sigma,)
     model_kwargs = {'y': y}
     return model, model_args, model_kwargs
+
+#######################################
+# constrained problems
+#######################################
+
+# uniform dist on T^2 torus embedded in R^3
+# Example 1 in Zappa & Holmes-Cerfon (2018)
+def torus_constraint(R, r, x):
+    return jnp.array([
+        jnp.square(R - jnp.linalg.norm(x[:-1])) + x[-1]*x[-1] - r*r
+    ])
+
+def torus_param(R, r, theta, phi):
+    cos_theta, sin_theta = jnp.cos(theta), jnp.sin(theta)
+    cos_phi, sin_phi = jnp.cos(phi), jnp.sin(phi)
+    u = R + r*cos_phi
+    return jnp.array([u*cos_theta, u*sin_theta, r*sin_phi])
+
+# need arctan2 to return angles in [0,2pi)
+arctan2pi = lambda x,y: jnp.remainder(jnp.arctan2(x,y), 2*jnp.pi)
+def inv_torus_param(R, r, x, y, z):
+    theta = arctan2pi(y, x)
+    d = jnp.hypot(x,y) - R
+    phi = arctan2pi(z, d)
+    return (theta, phi)
+
+###############################################################################
+# diagnostics
+###############################################################################
 
 def extremal_diagnostics(mcmc):
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -82,8 +82,8 @@ def orthonormal_constraint(x):
     X = x.reshape((d,d))
     G = jnp.inner(X,X)
     triu_inds = jnp.triu_indices(d)
-    G_triu = G[triu_inds[0],triu_inds[1]]
-    I_triu = jnp.identity(d)[triu_inds[0],triu_inds[1]]
+    G_triu = G[*triu_inds]
+    I_triu = jnp.identity(d)[*triu_inds]
     return G_triu - I_triu
 
 


### PR DESCRIPTION
Implements

Zappa, E., Holmes-Cerfon, M. and Goodman, J. (2018), Monte Carlo on Manifolds: Sampling Densities and Integrating Functions. Comm. Pure Appl. Math., 71: 2609-2647. https://doi.org/10.1002/cpa.21783

Xu, K., & Holmes-Cerfon, M. (2024). Monte Carlo on manifolds in high dimensions. Journal of Computational Physics, 506, 112939. https://doi.org/10.1016/j.jcp.2024.112939

Using the approach described in the latter, we achieve O(nm^2 + m^3) iteration complexity, heavily relying on jvp+vjp to avoid forming full Jacobians whenever possible.