### PR TITLE
Generalize constrained sampling to a forward model approach

### DIFF
--- a/automcmc/autohmc.py
+++ b/automcmc/autohmc.py
@@ -12,17 +12,17 @@ from automcmc import tempering
 class AutoHMC(autostep.AutoStep):
 
     def __init__(
-            self, 
-            *args, 
-            n_leapfrog_steps=32, 
-            forward_mode_ad=False, 
+            self,
+            *args,
+            n_leapfrog_steps=32,
+            forward_mode_ad=False,
             **kwargs
         ):
         super().__init__(*args, **kwargs)
         self.n_leapfrog_steps = n_leapfrog_steps
         self.forward_mode_ad = forward_mode_ad
         self.integrator = None
-            
+
     def init_extras(self, initial_state):
         if jnp.shape(initial_state.rng_key) == ():
             proto_x = initial_state.x
@@ -32,7 +32,7 @@ class AutoHMC(autostep.AutoStep):
             self.logprior_and_loglik, proto_x, self.forward_mode_ad
         )
         return initial_state
-    
+
     def kinetic_energy(self, state, precond_state):
         # compute kinetic energy
         # autoHMC works in "momentum" convention -- i.e., p_flat ~ N(0,M) -- as
@@ -42,18 +42,18 @@ class AutoHMC(autostep.AutoStep):
         Minv = precond_state.var
         Minv_p_flat = Minv @ p_flat if jnp.ndim(Minv) == 2 else Minv * p_flat
         return 0.5*jnp.dot(Minv_p_flat, p_flat)
-    
+
     def refresh_aux_vars(self, rng_key, state, precond_state):
         v_flat = random.normal(rng_key, jnp.shape(state.p_flat))
         U = precond_state.inv_var_triu_factor
         p_flat = U @ v_flat if jnp.ndim(U) == 2 else U * v_flat
         return state._replace(p_flat = p_flat)
-    
+
     def involution_main(self, step_size, state, precond_state):
         return self.integrator(
             step_size, state, precond_state, self.n_leapfrog_steps
         )
-    
+
     def involution_aux(self, state):
         return state._replace(p_flat = -state.p_flat)
 
@@ -74,11 +74,11 @@ class AutoHMC(autostep.AutoStep):
 #       1) Sampling p = Ly
 #       2) kinetic energy eval: [L^{-1}p]^T [L^{-1}p]
 #       3) For each leapfrog, a single matop (M^{-1}p)
-# The alternative is to work with y:=L^{-1}p, which gives the updates 
+# The alternative is to work with y:=L^{-1}p, which gives the updates
 # 	y* = y  - (eps/2)L^{-1}grad(U)(x)
 # 	x' = x  + eps (L^T)^{-1}y
 # 	y' = y* - (eps/2)L^{-1}grad(U)(x')
-# This means we need 
+# This means we need
 #   - To get L^{-1} and (L^{-1})^T
 #   - No matrix ops outside leapfrog
 #   - ...but 3 O(d^2) ops for every LF step!
@@ -112,10 +112,10 @@ def gen_integrator(logprior_and_loglik, proto_x, forward_mode_ad):
 
     def grad_flat_x_flat(x_flat, inv_temp):
         """
-        Flattened gradient of the potential evaluated at a flattened 
+        Flattened gradient of the potential evaluated at a flattened
         unconstrained state.
         """
-        # unflatten state and take gradient 
+        # unflatten state and take gradient
         # note: by default, `grad` and `jacfwd` take diff w.r.t. the first arg only
         x = unravel_fn(x_flat)
         if forward_mode_ad:
@@ -133,7 +133,7 @@ def gen_integrator(logprior_and_loglik, proto_x, forward_mode_ad):
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
         p_flat    = velocity_step(p_flat, step_size, grad_flat)
         return (x_flat, p_flat, step_size, precond_state, inv_temp), None
-    
+
     def integrator(step_size, state, precond_state, n_steps):
         # jax.debug.print("start: step_size={s}, precond_state={d}", ordered=True, s=step_size, d=precond_state)
         # explicitly unpack state: avoid using tuple unpacking as it breaks
@@ -164,13 +164,13 @@ def gen_integrator(logprior_and_loglik, proto_x, forward_mode_ad):
         x_flat    = position_step(x_flat, step_size, precond_state, p_flat)
         grad_flat = grad_flat_x_flat(x_flat, inv_temp)
         p_flat    = velocity_step(p_flat, 0.5*step_size, grad_flat)
-        
+
         # unravel, update state, and return it
         x_new = unravel_fn(x_flat)
         # jax.debug.print("final: x_new={x}, x_flat={xf}, grad={g}, p_flat={v}", ordered=True, x=x_new, xf=x_flat, g=grad_flat, v=p_flat)
 
         return state._replace(x = x_new, p_flat = p_flat)
-    
+
     return integrator
 
 

--- a/automcmc/automcmc.py
+++ b/automcmc/automcmc.py
@@ -88,7 +88,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         self._potential_fn = potential_fn
         self.logprior_and_loglik = logprior_and_loglik
         self._postprocess_fn = None
-        self._sample_fn = self.sample_single_chain
+        self._step_fn = self.sample_single_chain
         self.init_base_step_size = init_base_step_size
         self.selector = selector
         self.preconditioner = preconditioner
@@ -122,14 +122,21 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
             None
         )
 
-    def init_extras(self, state):
+    def init_extras(self, state: AutoMCMCState) -> AutoMCMCState:
         """
-        Carry out additional initializations not required by all
-        :class:`AutoMCMC` kernels.
+        Subclasses can overload this method to carry out additional
+        initializations. Note that the implementation must explicitly handle
+        the possibility of running in vectorized mode.
         """
         return state
 
-    # note: this is called by the enclosing numpyro.infer.MCMC object
+    # Note: this is called by the enclosing numpyro.infer.MCMC object, from the
+    # `_single_chain_mcmc` method. When running vectorized, the only thing that
+    # NumPyro does for us is make `rng_key` an array of PRNG keys. It is up to
+    # us to 1) detect this and 2) handle the required vectorization (i.e., do
+    # the vmapping). The same goes for the `sample` method (i.e., the stepping
+    # function), which is why here we take care of switching to a vmapped
+    # version if vectorization is detected
     def init(self, rng_key, num_warmup, initial_params, model_args, model_kwargs):
         # determine number of adaptation rounds
         self.adapt_rounds = utils.n_warmup_to_adapt_rounds(num_warmup)
@@ -202,7 +209,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
 
         # adjust the sampling function in case of vectorization
         if is_vectorized:
-            self._sample_fn = jax.vmap(self._sample_fn, in_axes=(0,None,None))
+            self._step_fn = jax.vmap(self._step_fn, in_axes=(0,None,None))
 
         return initial_state
 
@@ -230,7 +237,7 @@ class AutoMCMC(infer.mcmc.MCMCKernel, metaclass=ABCMeta):
         pass
 
     def sample(self, state, model_args, model_kwargs):
-        return self._sample_fn(state, model_args, model_kwargs)
+        return self._step_fn(state, model_args, model_kwargs)
 
     def get_diagnostics_str(self, state):
         return "avg_ss={:.1e}, rr={:.2f}, ap={:.2f}, lj={: .1e}".format(

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -17,9 +17,10 @@ class ConstraintState(NamedTuple):
         x_base: point that dictates the level set :math:`f^{-1}(\\{x\\})` and
             the tangent and normal spaces that determine the projections onto
             said level set. We assume `x_base` is flattened.
-        chol: Cholesky decomposition of :math:`J_xJ_x^T` where :math:`J_x`
-            is the Jacobian of the constraint evaluated at `x_base`.
-        log_abs_det: log of :math:`|(J_xJ_x^T)|^{-1/2}` computed using the
+        chol: a lower triangular matrix arising from the Cholesky decomposition
+            of :math:`J_xJ_x^T`, where :math:`J_x` is the Jacobian of the
+            constraint evaluated at `x_base`.
+        log_abs_det: log of :math:`|J_xJ_x^T|^{-1/2}` computed using the
             Cholesky decomposition.
     """
     is_satisfied: ArrayLike
@@ -33,7 +34,7 @@ def make_constraint_state(
         tol: ArrayLike
     ) -> ConstraintState:
     """
-    Build :class:`ConstraintState`.
+    Build :class:`ConstraintState` from a constraint function.
 
     :param constraint_fn: the constraint function.
     :param x_base: base point; see :class:`ConstraintState`.
@@ -47,6 +48,25 @@ def make_constraint_state(
     chol = jax.lax.linalg.cholesky(jnp.inner(J,J))
     log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
     return ConstraintState(is_satisfied, x_base, chol, log_abs_det)
+
+def make_constraint_state_for_fwd_model(
+        fwd_model: Callable[[ArrayLike], jax.Array],
+        obs_output: ArrayLike,
+        *args
+    ) -> ConstraintState:
+    """
+    Build :class:`ConstraintState` from a forward model and an observed output,
+    such that the constraint function is `f(x)=fwd_model(x)-obs_output`.
+
+    :param fwd_model: the forward model.
+    :param obs_output: an observed output of the forward model.
+    :param args: passed to :func:`make_constraint_state`.
+    :return: a :class:`ConstraintState`.
+    """
+    return make_constraint_state(
+        lambda x: fwd_model(x) - obs_output,
+        *args
+    )
 
 # project onto normal (N) space
 #   P[N]v = J^T(JJ^T)^{-1}Jv
@@ -119,6 +139,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             *args,
             preconditioner=preconditioning.IdentityDiagonalPreconditioner(), # we need rotational symmetry
             constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
+            fwd_model=None,
+            init_obs_output=None,
             solver_options = {},
             x_tols = {},
             **kwargs
@@ -128,7 +150,20 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             self.preconditioner, preconditioning.IdentityDiagonalPreconditioner
         ), "This method is justified only for `IdentityDiagonalPreconditioner`" \
           f" but I got instead {type(self.preconditioner)}"
-        self.constraint_fn = constraint_fn
+
+        if fwd_model is None:
+            assert init_obs_output is None or jnp.allclose(
+                init_obs_output, jnp.zeros_like(init_obs_output)
+            ), "You supplied a non-zero `init_obs_output` but no `fwd_model`"
+            if constraint_fn is not None:
+                fwd_model = constraint_fn
+            else:
+                raise ValueError(
+                    "You must supply one of `fwd_model` or `constraint_fn`"
+                )
+
+        self.fwd_model = fwd_model
+        self.init_obs_output = 0 if init_obs_output is None else init_obs_output
         self.solver_options = solver_options
         self.x_tols = x_tols
 
@@ -150,7 +185,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # project to the feasible set in the normal directions at cs.x_base
         #   solve for z: 0 = f(x + J^Tz) => set x' = x + J^Tz
         # since J^Tz = (z^TJ)^T, we can use vector-Jacobian prods (vjp)
-        f_val, f_vjp = jax.vjp(self.constraint_fn, cs.x_base)
+        f_val, f_vjp = jax.vjp(self.fwd_model, cs.x_base)
         z, *diagnostics, _ = utils.newton(
             lambda z: self.constraint_fn(x_flat + f_vjp(z)[0]),
             jnp.zeros_like(f_val),

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -217,12 +217,14 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         )
         return (x_flat, fms, diagnostics)
 
-    def init_extras(self, state):
-        # TODO: extract `fwd_model` for numpyro models (via a deterministic
-        # stmtnt+model_kwargs or a Delta dist (problem: breaks log_prob))
-
+    def init_fms_and_project(self, x, init_obs_output):
         # set the constraint tolerance
-        x_flat, unravel_fn = flatten_util.ravel_pytree(state.x)
+        # Note: even though this function may run inside vmap, tolerances are
+        # always singletons. Moreover, they don't depend on the value of `x`,
+        # just their shape. Furthermore, vmap is smart and reinterprets `.shape`
+        # (and `.size`, etc) so as to return the un-vmapped value. Hence, tols
+        # are the same scalars regardless of vectorization
+        x_flat, unravel_fn = flatten_util.ravel_pytree(x)
         if 'tol' not in self.solver_options:
             self.solver_options['tol'] = utils.newton_default_tol(x_flat)
 
@@ -237,20 +239,39 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # initialize the forward model state
         fms = make_fwd_model_state(
             self.fwd_model,
-            self.init_obs_output,
+            init_obs_output,
             x_flat,
             self.solver_options['tol']
         )
 
         # project to zero level set
         x_flat, fms, diagnostics = self.proj_level_set(x_flat, fms)
-        assert fms.cs.is_satisfied, "Cannot find feasible starting point. " \
-                                   f"Solver output:\n{diagnostics}"
+        return unravel_fn(x_flat), fms, diagnostics
+
+
+    # TODO: extract `fwd_model` for numpyro models (via a deterministic
+    # stmtnt+model_kwargs or a Delta dist (problem: breaks log_prob))
+    def init_extras(self, state):
+        rng_key_shape = jnp.shape(state.rng_key)
+        if rng_key_shape == ():
+            x, fms, diagnostics = self.init_fms_and_project(
+                state.x, self.init_obs_output
+            )
+        else:
+            assert (
+                jnp.ndim(self.init_obs_output) > 0 and
+                rng_key_shape[0] == self.init_obs_output.shape[0]
+            ), "`init_obs_output` must have a leading dimension equal to " \
+               f"the number of chains requested ({rng_key_shape[0]})"
+            x, fms, diagnostics = jax.vmap(self.init_fms_and_project)(
+                state.x, self.init_obs_output
+            )
+
+        assert jnp.all(fms.cs.is_satisfied), \
+            f"Cannot find feasible starting point. Solver output:\n{diagnostics}"
 
         # return updated state
-        return state._replace(
-            x = unravel_fn(x_flat), idiosyncratic = fms
-        )
+        return state._replace(x = x, idiosyncratic = fms)
 
     def kinetic_energy(self, state, precond_state):
         return 0.5*jnp.dot(state.p_flat, state.p_flat)

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Callable
+from typing import NamedTuple, Callable, Any
 
 import jax
 from jax.typing import ArrayLike
@@ -9,14 +9,13 @@ from automcmc.automcmc import AutoMCMCState
 
 class ConstraintState(NamedTuple):
     """
-    A :class:`NamedTuple` type for storing constraint-related quantities
-    evaluated at a specific point in space.
+    A :class:`NamedTuple` describing the zero-level set of a constraint.
 
     Attributes:
         is_satisfied: true if `f(x_base)=0` up to tolerance.
-        x_base: point that dictates the level set :math:`f^{-1}(\\{x\\})` and
-            the tangent and normal spaces that determine the projections onto
-            said level set. We assume `x_base` is flattened.
+        x_base: point that dictates the level set :math:`f^{-1}(\\{f(x)\\})`
+            and the tangent and normal spaces that determine the projections
+            onto said level set. We assume `x_base` is flattened.
         chol: a lower triangular matrix arising from the Cholesky decomposition
             of :math:`J_xJ_x^T`, where :math:`J_x` is the Jacobian of the
             constraint evaluated at `x_base`.
@@ -34,7 +33,7 @@ def make_constraint_state(
         tol: ArrayLike
     ) -> ConstraintState:
     """
-    Build :class:`ConstraintState` from a constraint function.
+    Build a :class:`ConstraintState`.
 
     :param constraint_fn: the constraint function.
     :param x_base: base point; see :class:`ConstraintState`.
@@ -49,23 +48,39 @@ def make_constraint_state(
     log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
     return ConstraintState(is_satisfied, x_base, chol, log_abs_det)
 
-def make_constraint_state_for_fwd_model(
+
+class ForwardModelState(NamedTuple):
+    """
+    A :class:`NamedTuple` describing a specific level set of a forward model.
+
+    Attributes:
+        cs: an instance of :class:`ConstraintState`.
+        obs_output: output of the forward model at `cs.x_base`.
+    """
+    cs: ConstraintState
+    obs_output: ArrayLike
+
+
+def make_fwd_model_state(
         fwd_model: Callable[[ArrayLike], jax.Array],
         obs_output: ArrayLike,
         *args
-    ) -> ConstraintState:
+    ) -> ForwardModelState:
     """
-    Build :class:`ConstraintState` from a forward model and an observed output,
-    such that the constraint function is `f(x)=fwd_model(x)-obs_output`.
+    Build :class:`ForwardModelState` from a forward model function and an
+    observed output.
 
     :param fwd_model: the forward model.
     :param obs_output: an observed output of the forward model.
     :param args: passed to :func:`make_constraint_state`.
-    :return: a :class:`ConstraintState`.
+    :return: a :class:`ForwardModelState`.
     """
-    return make_constraint_state(
-        lambda x: fwd_model(x) - obs_output,
-        *args
+    return ForwardModelState(
+        make_constraint_state(
+            lambda x: fwd_model(x) - obs_output,
+            *args
+        ),
+        obs_output
     )
 
 # project onto normal (N) space
@@ -170,37 +185,40 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def proj_level_set(
             self,
             x_flat: ArrayLike,
-            cs: ConstraintState
-        ) -> tuple:
+            fms: ForwardModelState
+        ) -> tuple[Any, ...]:
         """
-        Project a point on the constraint level set along the normal space
-        determined by a :class:`ConstraintState`.
+        Project a point on the level set determined by a
+        :class:`ForwardModelState`.
 
         :param ArrayLike x_flat: a vector.
-        :param ConstraintState cs: a :class:`ConstraintState` corresponding to
-            the base point which dictates the normal spaces.
-        :return tuple: projected vector, updated :class:`ConstraintState`, and
-            solver diagnostics.
+        :param ForwardModelState fms: determines the level set that is being
+            targeted.
+        :return tuple[Any, ...]: projected vector, updated
+            :class:`ForwardModelState`, and solver diagnostics.
         """
         # project to the feasible set in the normal directions at cs.x_base
         #   solve for z: 0 = f(x + J^Tz) => set x' = x + J^Tz
         # since J^Tz = (z^TJ)^T, we can use vector-Jacobian prods (vjp)
-        f_val, f_vjp = jax.vjp(self.fwd_model, cs.x_base)
+        f_val, f_vjp = jax.vjp(self.fwd_model, fms.cs.x_base) # Jac[fwd-mod] == Jac[constr]
         z, *diagnostics, _ = utils.newton(
-            lambda z: self.constraint_fn(x_flat + f_vjp(z)[0]),
+            lambda z: self.fwd_model(x_flat + f_vjp(z)[0]) - fms.obs_output,
             jnp.zeros_like(f_val),
             **self.solver_options
         )
         x_flat += f_vjp(z)[0]
 
         # update the constraint state and return
-        cs = make_constraint_state(
-            self.constraint_fn, x_flat, self.solver_options['tol']
+        fms = make_fwd_model_state(
+            self.fwd_model,
+            fms.obs_output,
+            x_flat,
+            self.solver_options['tol']
         )
-        return (x_flat, cs, diagnostics)
+        return (x_flat, fms, diagnostics)
 
     def init_extras(self, state):
-        # TODO: extract constraint_fn for numpyro models (via a deterministic
+        # TODO: extract `fwd_model` for numpyro models (via a deterministic
         # stmtnt+model_kwargs or a Delta dist (problem: breaks log_prob))
 
         # set the constraint tolerance
@@ -216,21 +234,23 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         if 'atol' not in self.x_tols:
             self.x_tols['atol'] = self.solver_options['tol'] # this val already scales with size of problem so no need to scale again
 
-        # initialize the constraint state
-        cs = make_constraint_state(
-            self.constraint_fn, x_flat, self.solver_options['tol']
+        # initialize the forward model state
+        fms = make_fwd_model_state(
+            self.fwd_model,
+            self.init_obs_output,
+            x_flat,
+            self.solver_options['tol']
         )
 
         # project to zero level set
-        x_flat, cs, diagnostics = self.proj_level_set(x_flat, cs)
-        if not cs.is_satisfied:
-            raise ValueError(
-                "Cannot find feasible starting point. " \
-                f"Solver output:\n{diagnostics}"
-            )
+        x_flat, fms, diagnostics = self.proj_level_set(x_flat, fms)
+        assert fms.cs.is_satisfied, "Cannot find feasible starting point. " \
+                                   f"Solver output:\n{diagnostics}"
 
         # return updated state
-        return state._replace(x = unravel_fn(x_flat), idiosyncratic = cs)
+        return state._replace(
+            x = unravel_fn(x_flat), idiosyncratic = fms
+        )
 
     def kinetic_energy(self, state, precond_state):
         return 0.5*jnp.dot(state.p_flat, state.p_flat)
@@ -239,8 +259,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def refresh_aux_vars(self, rng_key, state, precond_state):
         return state._replace(
             p_flat = proj_normal_tangent(
-                self.constraint_fn,
-                state.idiosyncratic,
+                self.fwd_model, # Jac[fwd-mod] == Jac[constraint]
+                state.idiosyncratic.cs,
                 random.normal(rng_key, jnp.shape(state.p_flat))
             )[-1]
         )
@@ -250,7 +270,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     #   - make the likelihood 0 when constraint is not satisfied, so that
     #     solver failures are handled gracefully by the autostep executors
     def postprocess_logprior_and_loglik(self, state, log_prior, log_lik):
-        cs = state.idiosyncratic
+        cs = state.idiosyncratic.cs
         log_prior += cs.log_abs_det
         log_lik = jnp.where(cs.is_satisfied, log_lik, -jnp.inf)
         return log_prior, log_lik
@@ -259,7 +279,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     # (i.e., invariant to flipping x<->y) based on L^2-norms
     # better than jnp.allclose which is == all(jnp.isclose)
     def close_in_ambient_space(self, x, y):
-        return utils.close_in_norm(x,y,self.x_tols['rtol'],self.x_tols['atol'])
+        return utils.close_in_norm(
+            x, y, self.x_tols['rtol'], self.x_tols['atol']
+        )
 
     def maybe_build_roundtrip_state(
             self,
@@ -281,10 +303,10 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         ) -> bool:
         passed = fwd_exponent == bwd_exponent
         passed = jnp.logical_and(
-            passed, proposed_state.idiosyncratic.is_satisfied
+            passed, proposed_state.idiosyncratic.cs.is_satisfied
         )
         passed = jnp.logical_and(
-            passed, roundtrip_state.idiosyncratic.is_satisfied
+            passed, roundtrip_state.idiosyncratic.cs.is_satisfied
         )
         passed = jnp.logical_and(
             passed,
@@ -311,21 +333,25 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         x_flat_out = x_flat + step_size * v_flat
 
         # project back to level set
-        x_flat_new,cs,_ = self.proj_level_set(x_flat_out, state.idiosyncratic)
+        x_flat_new, fms, _ = self.proj_level_set(
+            x_flat_out, state.idiosyncratic
+        )
 
         # transport the velocity by projecting the displacement vector x'-x
         # onto the tangent space at the new point
         # note: the displacement is on scale step_size * v, so we must divide
         # by the step size to get the right scale
         v_flat = proj_normal_tangent(
-            self.constraint_fn, cs, x_flat_new - x_flat
+            self.fwd_model, # Jac[fwd-mod] == Jac[constraint]
+            fms.cs,
+            x_flat_new - x_flat
         )[-1] / step_size
 
         # update state and return
         return state._replace(
             x = unravel_fn(x_flat_new),
             p_flat = v_flat,
-            idiosyncratic = cs
+            idiosyncratic = fms
         )
 
     # only need to flip sign of the velocity, which was already transported

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -95,7 +95,7 @@ def newton_default_tol(x: ArrayLike) -> jax.Array:
     # for float64, eps^(0.32) ~ 1e-5 which is the std tol use in most packages
     # we use eps^0.4 for a slightly tighter requirement.
     # This is then increased as log(n) because we focus on max-error, which
-    # scales logarithmically in the iid case (assuming mgf exists)
+    # scales logarithmically in the iid case (assuming subexponential tails)
     return jnp.maximum(1.0,jnp.log(x.size))*(jnp.finfo(x.dtype).eps**0.4)
 
 def newton_fn_value_err(val):

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -15,11 +15,25 @@ from numpyro.infer import MCMC
 class TestConstrained(unittest.TestCase):
 
     def test_invalid_inputs(self):
-        with self.assertRaises(AssertionError):
+        pot = lambda x: 0.0
+        with self.assertRaisesRegex(ValueError, "You must supply one"):
+            constrained.AutoConstrainedRWMH(potential_fn=pot)
+
+        with self.assertRaisesRegex(AssertionError,"This method is justified"):
             constrained.AutoConstrainedRWMH(
-                potential_fn=lambda x: 0.0,
+                potential_fn=pot,
                 preconditioner=preconditioning.FixedDensePreconditioner(),
             )
+
+        # check unfeasible problem is caught
+        init_params = jnp.zeros(5)
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=pot,
+            fwd_model=lambda x: jnp.ones_like(x, shape=(2,)),
+            init_obs_output=jnp.array([-3,3]), # not in range of fwd mod
+        )
+        with self.assertRaisesRegex(AssertionError, "Cannot find feasible"):
+            kernel.init(jax.random.key(1), 0, init_params, (), {})
 
     def test_proj_normal_tangent(self):
         d = 3

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -87,7 +87,7 @@ class TestConstrained(unittest.TestCase):
                     init_params = jax.random.normal(randn_key, (n_dim,))
                     state = kernel.init(init_key, 0, init_params, (), {})
                     tol = kernel.solver_options['tol']
-                    self.assertTrue(state.idiosyncratic.is_satisfied)
+                    self.assertTrue(state.idiosyncratic.cs.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(constraint_fn(state.x)), tol
                     )
@@ -103,7 +103,7 @@ class TestConstrained(unittest.TestCase):
                     )
                     self.assertAlmostEqual(
                         state.log_prior,
-                        state.idiosyncratic.log_abs_det - potential_fn(state.x),
+                        state.idiosyncratic.cs.log_abs_det - potential_fn(state.x),
                         delta=tol
                     )
 
@@ -111,7 +111,7 @@ class TestConstrained(unittest.TestCase):
                     state_half = kernel.involution_main(
                         step_size, state, precond_state
                     )
-                    self.assertTrue(state_half.idiosyncratic.is_satisfied)
+                    self.assertTrue(state_half.idiosyncratic.cs.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(constraint_fn(state_half.x)),
                         tol
@@ -131,7 +131,7 @@ class TestConstrained(unittest.TestCase):
                     state_onehalf = kernel.involution_main(
                         step_size, state_one, precond_state
                     )
-                    self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
+                    self.assertTrue(state_onehalf.idiosyncratic.cs.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(
                             constraint_fn(state_onehalf.x)
@@ -192,7 +192,7 @@ class TestConstrained(unittest.TestCase):
         n_warm, n_keep = utils.split_n_rounds(15)
         thinning=32 # %ESS ~ 1/32
         init_params = jnp.ones(3) # init outside level set on purpose
-        extra_fields = ('idiosyncratic.log_abs_det',)
+        extra_fields = ('idiosyncratic.cs.log_abs_det',)
         for sel in (
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
@@ -240,7 +240,7 @@ class TestConstrained(unittest.TestCase):
         init_params=jnp.full((3,), 0.5) # init in interior of cone
         n_warm, n_keep = utils.split_n_rounds(14)
         thinning=16 # %ESS ~ 1/16
-        extra_fields = ('idiosyncratic.log_abs_det',)
+        extra_fields = ('idiosyncratic.cs.log_abs_det',)
         for sel in (
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
@@ -292,7 +292,7 @@ class TestConstrained(unittest.TestCase):
         init_params=jax.random.normal(init_key, (n_dim,)) # init in interior of cone
         n_warm, n_keep = utils.split_n_rounds(16)
         thinning=2**6 # %ESS ~ 1/64
-        extra_fields = ('idiosyncratic.log_abs_det',)
+        extra_fields = ('idiosyncratic.cs.log_abs_det',)
         rng_key, mcmc_key = jax.random.split(rng_key)
         kernel = constrained.AutoConstrainedRWMH(
             potential_fn=potential_fn,

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -332,6 +332,66 @@ class TestConstrained(unittest.TestCase):
         traces = jax.vmap(lambda v: jnp.diag(v.reshape((d,d))).sum())(mcmc.get_samples())
         self.assertGreater(stats.ks_1samp(traces, stats.norm.cdf).pvalue, 0.01)
 
+    def test_vectorized_sampling(self):
+        # params
+        n_chains = 128
+        n_dim = 2
+        rng_key = jax.random.key(9)
+        n_warm, n_keep = utils.split_n_rounds(10)
+
+        # define an equally spaced grid in [0,1]
+        # check the Riemann integral recovers the truth (2/3) for expected radius
+        init_obs_output = jnp.arange(1, n_chains+1).reshape((n_chains,1))/n_chains
+        dr = init_obs_output[1,0]-init_obs_output[0,0]
+        assert jnp.isclose(
+            2*dr*jnp.square(init_obs_output).sum(), 2/3, rtol=0.02
+        )
+
+        # define sampler
+        potential_fn=lambda x: jnp.zeros((), x.dtype)
+        fwd_model=lambda x: jnp.array([jnp.linalg.norm(x)])
+        rng_key, params_key = jax.random.split(rng_key)
+        init_params = jax.random.normal(params_key,(n_chains, n_dim))
+        mcmc_keys = jax.random.split(rng_key, n_chains)
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=potential_fn,
+            fwd_model=fwd_model,
+            init_obs_output=init_obs_output
+        )
+
+        # run mcmc and get samples
+        mcmc = MCMC(
+            kernel,
+            num_warmup=n_warm,
+            num_samples=n_keep,
+            thinning=16,
+            num_chains=n_chains,
+            chain_method="vectorized",
+            progress_bar=False
+        )
+        mcmc.run(mcmc_keys,init_params=init_params)
+        samples = mcmc.get_samples(True)
+
+        # make sure we didn't request too small radii
+        assert init_obs_output[0] > kernel.solver_options['tol']
+
+        # check that the fwd model is respected along chains at every sample step
+        fwd_vals = jax.vmap(jax.vmap(fwd_model))(samples)
+        assert jnp.all(
+            jax.vmap(
+                partial(jnp.allclose, rtol=0, atol=kernel.solver_options['tol']),
+                in_axes=(1,None),
+            )(fwd_vals, init_obs_output)
+        )
+
+        # but also check that the submanifolds are explored by ensuring the
+        # angles follow a Unif(-pi,pi) distribution
+        # use a simple histogram check instead of KS test (too sensitive at
+        # this number of samples, which are not really indep anyway)
+        # impose grid to avoid being fooled by constant data
+        angles = jnp.arctan2(samples[:,:,0],samples[:,:,1]).flatten()
+        hist = jnp.histogram(angles,bins=jnp.linspace(-jnp.pi, jnp.pi, 11))
+        assert jnp.allclose(hist[0], samples.size/(10*n_dim), rtol=0.1)
 
 
 if __name__ == '__main__':

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -332,12 +332,13 @@ class TestConstrained(unittest.TestCase):
         traces = jax.vmap(lambda v: jnp.diag(v.reshape((d,d))).sum())(mcmc.get_samples())
         self.assertGreater(stats.ks_1samp(traces, stats.norm.cdf).pvalue, 0.01)
 
-    def test_vectorized_sampling(self):
+    def test_constrained_vectorized(self):
         # params
         n_chains = 64
         n_dim = 2
         rng_key = jax.random.key(9)
         n_warm, n_keep = utils.split_n_rounds(10)
+        thinning=16
 
         # define an equally spaced grid in [0,1]
         # check the Riemann integral recovers the truth (2/3) for expected radius
@@ -350,9 +351,8 @@ class TestConstrained(unittest.TestCase):
         # define sampler
         potential_fn=lambda x: jnp.zeros((), x.dtype)
         fwd_model=lambda x: jnp.array([jnp.linalg.norm(x)])
-        rng_key, params_key = jax.random.split(rng_key)
+        mcmc_key, params_key = jax.random.split(rng_key)
         init_params = jax.random.normal(params_key,(n_chains, n_dim))
-        mcmc_keys = jax.random.split(rng_key, n_chains)
         kernel = constrained.AutoConstrainedRWMH(
             potential_fn=potential_fn,
             fwd_model=fwd_model,
@@ -364,12 +364,12 @@ class TestConstrained(unittest.TestCase):
             kernel,
             num_warmup=n_warm,
             num_samples=n_keep,
-            thinning=16,
+            thinning=thinning,
             num_chains=n_chains,
             chain_method="vectorized",
             progress_bar=False
         )
-        mcmc.run(mcmc_keys,init_params=init_params)
+        mcmc.run(mcmc_key,init_params=init_params)
         samples = mcmc.get_samples(True)
 
         # make sure we didn't request too small radii

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -334,7 +334,7 @@ class TestConstrained(unittest.TestCase):
 
     def test_vectorized_sampling(self):
         # params
-        n_chains = 128
+        n_chains = 64
         n_dim = 2
         rng_key = jax.random.key(9)
         n_warm, n_keep = utils.split_n_rounds(10)
@@ -343,8 +343,8 @@ class TestConstrained(unittest.TestCase):
         # check the Riemann integral recovers the truth (2/3) for expected radius
         init_obs_output = jnp.arange(1, n_chains+1).reshape((n_chains,1))/n_chains
         dr = init_obs_output[1,0]-init_obs_output[0,0]
-        assert jnp.isclose(
-            2*dr*jnp.square(init_obs_output).sum(), 2/3, rtol=0.02
+        self.assertAlmostEqual(
+            2*dr*jnp.square(init_obs_output).sum(), 2/3, delta=0.02
         )
 
         # define sampler
@@ -373,16 +373,16 @@ class TestConstrained(unittest.TestCase):
         samples = mcmc.get_samples(True)
 
         # make sure we didn't request too small radii
-        assert init_obs_output[0] > kernel.solver_options['tol']
+        self.assertGreater(init_obs_output[0,0], kernel.solver_options['tol'])
 
         # check that the fwd model is respected along chains at every sample step
         fwd_vals = jax.vmap(jax.vmap(fwd_model))(samples)
-        assert jnp.all(
+        self.assertTrue(jnp.all(
             jax.vmap(
                 partial(jnp.allclose, rtol=0, atol=kernel.solver_options['tol']),
                 in_axes=(1,None),
             )(fwd_vals, init_obs_output)
-        )
+        ))
 
         # but also check that the submanifolds are explored by ensuring the
         # angles follow a Unif(-pi,pi) distribution
@@ -391,7 +391,9 @@ class TestConstrained(unittest.TestCase):
         # impose grid to avoid being fooled by constant data
         angles = jnp.arctan2(samples[:,:,0],samples[:,:,1]).flatten()
         hist = jnp.histogram(angles,bins=jnp.linspace(-jnp.pi, jnp.pi, 11))
-        assert jnp.allclose(hist[0], samples.size/(10*n_dim), rtol=0.1)
+        self.assertTrue(
+            jnp.allclose(hist[0], samples.size/(10*n_dim), rtol=0.1)
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Generalize the current $f(x)=0$ approach to $f(x)=y$. Also implements vectorized sampling, in such a way that each chain may use a different value of $y$. Therefore, multiple level sets can be sampled concurrently.