### PR TITLE
add robustness to constrained sampling

### DIFF
--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,137 +1,217 @@
+from abc import ABCMeta, abstractmethod
 from typing import NamedTuple, Callable, Any
 
 import jax
 from jax.typing import ArrayLike
 from jax import flatten_util, random, numpy as jnp
 
-from automcmc import utils, autostep, preconditioning
+from automcmc import utils, autostep, preconditioning, optimization
 from automcmc.automcmc import AutoMCMCState
 
-class ConstraintState(NamedTuple):
+DEBUG_CONSTRAINED_SAMPLING = False
+
+###############################################################################
+# Classes that handle the projection onto the normal and tangent spaces
+###############################################################################
+
+class LevelSetState(NamedTuple):
     """
-    A :class:`NamedTuple` describing the zero-level set of a constraint.
+    A :class:`NamedTuple` describing the forward model around a base point, and
+    its agreement with an observed model output.
 
     Attributes:
-        is_satisfied: true if `f(x_base)=0` up to tolerance.
         x_base: point that dictates the level set :math:`f^{-1}(\\{f(x)\\})`
-            and the tangent and normal spaces that determine the projections
-            onto said level set. We assume `x_base` is flattened.
-        chol: a lower triangular matrix arising from the Cholesky decomposition
-            of :math:`J_xJ_x^T`, where :math:`J_x` is the Jacobian of the
-            constraint evaluated at `x_base`.
-        log_abs_det: log of :math:`|J_xJ_x^T|^{-1/2}` computed using the
-            Cholesky decomposition.
+            We assume `x_base` is one-dimensional (i.e., a vector).
+        obs_output: an output of the forward model :math:`y`, dictating the
+            level set :math:`f^{-1}(y)`.
+        is_satisfied: true if `f(x_base)=y` (up to tolerance); i.e., if the two
+            level sets described above are the same.
+        log_abs_det: logarithm of :math:`|J_xJ_x^T|^{-1/2}` at `x_base`.
+        mat: a matrix used for projection onto the constraint set. Depends on
+            the handler used.
     """
+    x_base: jax.Array
+    obs_output: jax.Array
     is_satisfied: ArrayLike
-    x_base: ArrayLike
-    chol: jax.Array
     log_abs_det: jax.Array
-
-def make_constraint_state(
-        constraint_fn: Callable[[ArrayLike], jax.Array],
-        x_base: ArrayLike,
-        tol: ArrayLike
-    ) -> ConstraintState:
-    """
-    Build a :class:`ConstraintState`.
-
-    :param constraint_fn: the constraint function.
-    :param x_base: base point; see :class:`ConstraintState`.
-    :param tol: tolerance for constraint satisfiability.
-    :return: a :class:`ConstraintState` corresponding to `x_base`.
-    """
-    J, f_val = jax.jacrev(lambda x: 2*(constraint_fn(x),),has_aux=True)(x_base) # get Jacobian and value in one pass
-    is_satisfied = utils.newton_fn_value_err(f_val) < tol
-    m, n = jnp.shape(J)
-    assert m < n
-    chol = jax.lax.linalg.cholesky(jnp.inner(J,J))
-    log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
-    return ConstraintState(is_satisfied, x_base, chol, log_abs_det)
+    mat: jax.Array
 
 
-class ForwardModelState(NamedTuple):
-    """
-    A :class:`NamedTuple` describing a specific level set of a forward model.
+class LevelSetHandler(metaclass=ABCMeta):
 
-    Attributes:
-        cs: an instance of :class:`ConstraintState`.
-        obs_output: output of the forward model at `cs.x_base`.
-    """
-    cs: ConstraintState
-    obs_output: ArrayLike
+    @staticmethod
+    def get_jacobian_and_check_output(fwd_model, obs_output, x_base, tol):
+        # get Jacobian and value in one pass
+        # use reverse-mode because we work in the m<n world
+        J, f_val = jax.jacrev(
+            lambda x: 2*(fwd_model(x),), has_aux=True
+        )(x_base)
+        is_satisfied = utils.newton_fn_value_err(f_val-obs_output) < tol
+        m, n = jnp.shape(J)
+        assert m < n
+        return J, is_satisfied
 
-
-def make_fwd_model_state(
+    @abstractmethod
+    def make_levelset_state(
+        self,
         fwd_model: Callable[[ArrayLike], jax.Array],
         obs_output: ArrayLike,
-        *args
-    ) -> ForwardModelState:
-    """
-    Build :class:`ForwardModelState` from a forward model function and an
-    observed output.
+        x_base: ArrayLike,
+        tol: ArrayLike
+    ) -> LevelSetState:
+        """
+        Build :class:`LevelSetState` from a forward model function and an
+        observed output.
 
-    :param fwd_model: the forward model.
-    :param obs_output: an observed output of the forward model.
-    :param args: passed to :func:`make_constraint_state`.
-    :return: a :class:`ForwardModelState`.
-    """
-    return ForwardModelState(
-        make_constraint_state(
-            lambda x: fwd_model(x) - obs_output,
-            *args
-        ),
-        obs_output
-    )
+        :param fwd_model: the forward model.
+        :param obs_output: an observed output of the forward model.
+        :param x_base: base point; see :class:`LevelSetState`.
+        :param tol: tolerance for constraint satisfiability.
+        :return: a :class:`LevelSetState` corresponding to `x_base`.
+        """
+        pass
 
-# project onto normal (N) space
-#   P[N]v = J^T(JJ^T)^{-1}Jv
-# Following Xu&Holmes-Cerfon(2024), we can do this in steps
-#   1) u = Jv --> single jvp, O(1 func eval). For norm-like f, this is O(nm)
-#   2) solve for w: LL^Tw=u <=> w = L^{-T}[L^{-1}u]
-#                           <=> t=L^{-1}u and w=L^{-T}t
-#       a) O(m^2) triangular solve for t: Lt = u
-#       b) O(m^2) triangular solve for w: L^Tw=t
-#   3) P[N]v = J^Tw = (w^TJ)^T --> single vjp, O(1 func eval)
-# Cost: O(nm + m^2)
-def proj_normal(
-        constraint_fn: Callable[[ArrayLike], jax.Array],
-        cs: ConstraintState,
+    @staticmethod
+    @abstractmethod
+    def proj_normal(
+        fwd_model: Callable[[ArrayLike], jax.Array],
+        lss: LevelSetState,
         v: ArrayLike
     ) -> jax.Array:
-    """
-    Project a vector onto the normal space at `cs.x_base`.
+        """
+        Project a vector onto the normal space dictated by a
+        :class:`LevelSetState`.
 
-    :param constraint_fn: the constraint function.
-    :param cs: a :class:`ConstraintState` dictating the normal space.
-    :param v: vector to project.
-    :return: normal component of `v`.
-    """
-    u = jax.jvp(constraint_fn, (cs.x_base,), (v,))[-1]
-    t = jax.lax.linalg.triangular_solve(cs.chol, u, lower=True) # == jnp.linalg.solve(cs.chol, u)
-    w = jax.lax.linalg.triangular_solve(
-        cs.chol, t, lower=True, transpose_a=True # == jnp.linalg.solve(cs.chol.T, t)
-    )
-    f_vjp = jax.vjp(constraint_fn, cs.x_base)[-1]
-    return f_vjp(w)[0]
+        :param fwd_model: the forward model.
+        :param lss: a :class:`LevelSetState` dictating the normal space.
+        :param v: vector to project.
+        :return: normal component of `v`.
+        """
+        pass
 
-# project onto normal (N) and tangent (T) spaces
-# same as cost of just doing the normal part
-def proj_normal_tangent(
-        constraint_fn: Callable[[ArrayLike], jax.Array],
-        cs: ConstraintState,
-        v: ArrayLike
-    ) -> tuple[jax.Array, jax.Array]:
-    """
-    Project a vector onto the normal and tangent spaces at `cs.x_base`.
+    # project onto normal (N) and tangent (T) spaces
+    # same as cost of just doing the normal part
+    def proj_normal_tangent(
+            self,
+            fwd_model: Callable[[ArrayLike], jax.Array],
+            lss: LevelSetState,
+            v: ArrayLike
+        ) -> tuple[jax.Array, jax.Array]:
+        """
+        Project a vector onto the normal and tangent spaces dictated by a
+        :class:`LevelSetState`.
 
-    :param constraint_fn: the constraint function.
-    :param cs: a :class:`ConstraintState` dictating the normal space.
-    :param v: vector to project.
-    :return: normal and tangent components of `v`.
-    """
-    PNv = proj_normal(constraint_fn, cs, v)
-    return (PNv, v - PNv)
+        :param fwd_model: the forward model.
+        :param lss: a :class:`LevelSetState`.
+        :param v: vector to project.
+        :return: normal and tangent components of `v`.
+        """
+        PNv = self.proj_normal(fwd_model, lss, v)
+        return (PNv, v - PNv)
 
+
+class LevelSetHandlerChol(LevelSetHandler):
+    """
+    Handles the projection onto the normal space using an approach based on
+    `jvp`, `vjp`, and the Cholesky decomposition of :math:`J_xJ_x^T` [1].
+    Its main benefit is that projections have cost :math:`O(2nm + m^2)` and
+    memory :math:`O(n+m^2)`. The linear scaling in `n` makes it ideal for
+    high-dimensional settings. However, the method suffers from low accuracy
+    issues when the level sets exhibit high curvature.
+
+    .. rubric:: References
+
+    [1] Xu, K., & Holmes-Cerfon, M. (2024). Monte Carlo on manifolds in high
+    dimensions. *Journal of Computational Physics*, 506, 112939.
+    """
+    def make_levelset_state(
+            self,
+            fwd_model: Callable[[ArrayLike], jax.Array],
+            obs_output: ArrayLike,
+            x_base: ArrayLike,
+            tol: ArrayLike
+        ) -> LevelSetState:
+        J, is_satisfied = self.get_jacobian_and_check_output(
+            fwd_model, x_base, obs_output, tol
+        )
+        chol = jax.lax.linalg.cholesky(jnp.inner(J,J))
+        log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
+        return LevelSetState(
+            x_base, obs_output, is_satisfied, log_abs_det, chol
+        )
+
+    # project onto normal (N) space
+    #   P[N]v = J^T(JJ^T)^{-1}Jv
+    # Following Xu&Holmes-Cerfon(2024), we can do this in steps
+    #   1) u = Jv --> single jvp, O(1 func eval). For norm-like f, this is O(nm)
+    #   2) solve for w: LL^Tw=u <=> w = L^{-T}[L^{-1}u]
+    #                           <=> t=L^{-1}u and w=L^{-T}t
+    #       a) O(m^2) triangular solve for t: Lt = u
+    #       b) O(m^2) triangular solve for w: L^Tw=t
+    #   3) P[N]v = J^Tw = (w^TJ)^T --> single vjp, O(1 func eval)
+    # Cost: O(2nm + m^2)
+    @staticmethod
+    def proj_normal(
+            fwd_model: Callable[[ArrayLike], jax.Array],
+            lss: LevelSetState,
+            v: ArrayLike
+        ) -> jax.Array:
+        chol = lss.mat
+        u = jax.jvp(fwd_model, (lss.x_base,), (v,))[-1]
+        t = jax.lax.linalg.triangular_solve(chol, u, lower=True) # == jnp.linalg.solve(cs.chol, u)
+        w = jax.lax.linalg.triangular_solve(
+            chol, t, lower=True, transpose_a=True # == jnp.linalg.solve(cs.chol.T, t)
+        )
+        f_vjp = jax.vjp(fwd_model, lss.x_base)[-1]
+        return f_vjp(w)[0]
+
+
+class LevelSetHandlerQR(LevelSetHandler):
+    """
+    Handles the projection onto the normal space using the QR decomposition
+    of :math:`J_x^T` [1]. It is simple and remarkably accurate even in high
+    curvature scenarios. However, its cost is :math:`O(nm^2+n^2m)` and uses
+    space :math:`O(nm)`, making it expensive in the big `n` scenario.
+
+    .. rubric:: References
+
+    [1] Zappa, E., Holmes-Cerfon, M. & Goodman, J. (2018).
+    Monte Carlo on manifolds: Sampling densities and integrating functions.
+    *Comm. Pure Appl. Math.*, 71, 2609-2647.
+    """
+    def make_levelset_state(
+            self,
+            fwd_model: Callable[[ArrayLike], jax.Array],
+            obs_output: ArrayLike,
+            x_base: ArrayLike,
+            tol: ArrayLike
+        ) -> LevelSetState:
+        J, is_satisfied = self.get_jacobian_and_check_output(
+            fwd_model, x_base, obs_output, tol
+        )
+        Q,R = jnp.linalg.qr(J.T)
+        log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
+        return LevelSetState(
+            x_base, obs_output, is_satisfied, log_abs_det, Q
+        )
+
+    # project onto normal (N) space
+    #   P[N]v = J^T(JJ^T)^{-1}Jv
+    # If J^T = QR, then JJ^T = R^TR and
+    #   P[N]v = [QR(R^TR)^{-1}R^TQ^T]v = QQ^Tv
+    @staticmethod
+    def proj_normal(
+            fwd_model: Callable[[ArrayLike], jax.Array],
+            lss: LevelSetState,
+            v: ArrayLike
+        ) -> jax.Array:
+        Q = lss.mat
+        return Q @ jnp.dot(v,Q)
+
+
+###############################################################################
+# Sampler definition
+###############################################################################
 
 class AutoConstrainedRWMH(autostep.AutoStep):
     """
@@ -158,6 +238,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             init_obs_output=None,
             solver_options = {},
             x_tols = {},
+            levelset_finder_settings = None,
             **kwargs
         ):
         super().__init__(*args,preconditioner=preconditioner,**kwargs)
@@ -181,50 +262,80 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         self.init_obs_output = 0 if init_obs_output is None else init_obs_output
         self.solver_options = solver_options
         self.x_tols = x_tols
+        if levelset_finder_settings is None:
+            # shallow copy is enough since we only change `n_iter`
+            levelset_finder_settings = (
+                optimization.DEFAULT_OPTIMIZE_FUN_SETTINGS['NADAMW'].copy()
+            )
+            levelset_finder_settings['n_iter'] = 256
+
+        self.levelset_finder_settings = levelset_finder_settings
 
     def proj_level_set(
             self,
             x_flat: ArrayLike,
-            fms: ForwardModelState
+            lss: LevelSetState
         ) -> tuple[Any, ...]:
         """
         Project a point on the level set determined by a
-        :class:`ForwardModelState`.
+        :class:`LevelSetState`.
 
         :param ArrayLike x_flat: a vector.
-        :param ForwardModelState fms: determines the level set that is being
+        :param LevelSetState lss: determines the level set that is being
             targeted.
         :return tuple[Any, ...]: projected vector, updated
-            :class:`ForwardModelState`, and solver diagnostics.
+            :class:`LevelSetState`, and solver diagnostics.
         """
         # project to the feasible set in the normal directions at cs.x_base
         #   solve for z: 0 = f(x + J^Tz) => set x' = x + J^Tz
         # since J^Tz = (z^TJ)^T, we can use vector-Jacobian prods (vjp)
-        f_val, f_vjp = jax.vjp(self.fwd_model, fms.cs.x_base) # Jac[fwd-mod] == Jac[constr]
+        f_val, f_vjp = jax.vjp(self.fwd_model, lss.x_base) # Jac[fwd-mod] == Jac[constr]
         z, *diagnostics, _ = utils.newton(
-            lambda z: self.fwd_model(x_flat + f_vjp(z)[0]) - fms.obs_output,
+            lambda z: self.fwd_model(x_flat + f_vjp(z)[0]) - lss.obs_output,
             jnp.zeros_like(f_val),
             **self.solver_options
         )
         x_flat += f_vjp(z)[0]
 
         # update the constraint state and return
-        fms = make_fwd_model_state(
+        lss = make_fwd_model_state(
             self.fwd_model,
-            fms.obs_output,
+            lss.obs_output,
             x_flat,
             self.solver_options['tol']
         )
-        return (x_flat, fms, diagnostics)
+        return (x_flat, lss, diagnostics)
 
-    def init_fms_and_project(self, x, init_obs_output):
+    # preliminary pass with gradient descent on least-squares loss to get close to
+    # levelset, as Newton fails when initialized too far away
+    def find_levelset(self, x_flat, init_obs_output):
+        n_iter = self.levelset_finder_settings['n_iter']
+        target_fun = lambda x: jnp.square(
+            self.fwd_model(x) - init_obs_output
+        ).sum()
+        solver, step_fn = optimization.make_nadamw_solver(
+            target_fun, self.levelset_finder_settings['solver_params'], False
+        )
+        opt_state = solver.init(x_flat)
+        return jax.lax.scan(
+            lambda t,_: (step_fn(t[0], t[1])[:2], None),
+            (x_flat, opt_state),
+            length=n_iter
+        )[0][0]
+
+    def init_lss_and_project(self, x, init_obs_output):
+        # Home in on the levelset using gradient descent (currently NADAMW)
+        # This is required because Newton's method fails when started too far
+        # from the levelset
+        x_flat, unravel_fn = flatten_util.ravel_pytree(x)
+        x_flat = self.find_levelset(x_flat, init_obs_output)
+
         # set the constraint tolerance
         # Note: even though this function may run inside vmap, tolerances are
         # always singletons. Moreover, they don't depend on the value of `x`,
         # just their shape. Furthermore, vmap is smart and reinterprets `.shape`
         # (and `.size`, etc) so as to return the un-vmapped value. Hence, tols
         # are the same scalars regardless of vectorization
-        x_flat, unravel_fn = flatten_util.ravel_pytree(x)
         if 'tol' not in self.solver_options:
             self.solver_options['tol'] = utils.newton_default_tol(x_flat)
 
@@ -237,7 +348,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             self.x_tols['atol'] = self.solver_options['tol'] # this val already scales with size of problem so no need to scale again
 
         # initialize the forward model state
-        fms = make_fwd_model_state(
+        lss = make_fwd_model_state(
             self.fwd_model,
             init_obs_output,
             x_flat,
@@ -245,8 +356,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         )
 
         # project to zero level set
-        x_flat, fms, diagnostics = self.proj_level_set(x_flat, fms)
-        return unravel_fn(x_flat), fms, diagnostics
+        x_flat, lss, diagnostics = self.proj_level_set(x_flat, lss)
+        return unravel_fn(x_flat), lss, diagnostics
 
 
     # TODO: extract `fwd_model` for numpyro models (via a deterministic
@@ -254,7 +365,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def init_extras(self, state):
         rng_key_shape = jnp.shape(state.rng_key)
         if rng_key_shape == ():
-            x, fms, diagnostics = self.init_fms_and_project(
+            x, lss, diagnostics = self.init_lss_and_project(
                 state.x, self.init_obs_output
             )
         else:
@@ -263,15 +374,15 @@ class AutoConstrainedRWMH(autostep.AutoStep):
                 rng_key_shape[0] == self.init_obs_output.shape[0]
             ), "`init_obs_output` must have a leading dimension equal to " \
                f"the number of chains requested ({rng_key_shape[0]})"
-            x, fms, diagnostics = jax.vmap(self.init_fms_and_project)(
+            x, lss, diagnostics = jax.vmap(self.init_lss_and_project)(
                 state.x, self.init_obs_output
             )
 
-        assert jnp.all(fms.cs.is_satisfied), \
+        assert jnp.all(lss.cs.is_satisfied), \
             f"Cannot find feasible starting point. Solver output:\n{diagnostics}"
 
         # return updated state
-        return state._replace(x = x, idiosyncratic = fms)
+        return state._replace(x = x, idiosyncratic = lss)
 
     def kinetic_energy(self, state, precond_state):
         return 0.5*jnp.dot(state.p_flat, state.p_flat)
@@ -323,11 +434,20 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             roundtrip_state: AutoMCMCState
         ) -> bool:
         passed = fwd_exponent == bwd_exponent
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "exponents match: {}", passed, ordered=True
+        )
         passed = jnp.logical_and(
             passed, proposed_state.idiosyncratic.cs.is_satisfied
         )
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "and prop state is feasible: {}", passed, ordered=True
+        )
         passed = jnp.logical_and(
             passed, roundtrip_state.idiosyncratic.cs.is_satisfied
+        )
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "and rt state is feasible: {}", passed, ordered=True
         )
         passed = jnp.logical_and(
             passed,
@@ -336,12 +456,24 @@ class AutoConstrainedRWMH(autostep.AutoStep):
                 flatten_util.ravel_pytree(roundtrip_state.x)[0]
             )
         )
-        return jnp.logical_and(
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "and rt state is close to init: {}", passed, ordered=True
+        )
+        passed = jnp.logical_and(
             passed,
             self.close_in_ambient_space(
                 initial_state.p_flat, roundtrip_state.p_flat
             )
         )
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "and rt vel is close to init: {}", passed, ordered=True
+        )
+        DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
+            "\ninit_st={}\n\nprop_st={}\n\nrt_st={}",
+            initial_state, proposed_state, roundtrip_state,
+            ordered=True
+        )
+        return passed
 
 
     # Both position and velocity are affected by this transform
@@ -354,7 +486,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         x_flat_out = x_flat + step_size * v_flat
 
         # project back to level set
-        x_flat_new, fms, _ = self.proj_level_set(
+        x_flat_new, lss, _ = self.proj_level_set(
             x_flat_out, state.idiosyncratic
         )
 
@@ -364,7 +496,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # by the step size to get the right scale
         v_flat = proj_normal_tangent(
             self.fwd_model, # Jac[fwd-mod] == Jac[constraint]
-            fms.cs,
+            lss.cs,
             x_flat_new - x_flat
         )[-1] / step_size
 
@@ -372,7 +504,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         return state._replace(
             x = unravel_fn(x_flat_new),
             p_flat = v_flat,
-            idiosyncratic = fms
+            idiosyncratic = lss
         )
 
     # only need to flip sign of the velocity, which was already transported

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import NamedTuple, Callable, Any
+from typing import NamedTuple, Callable, Any, Optional
 
 import jax
 from jax.typing import ArrayLike
@@ -7,6 +7,10 @@ from jax import flatten_util, random, numpy as jnp
 
 from automcmc import utils, autostep, preconditioning, optimization
 from automcmc.automcmc import AutoMCMCState
+from automcmc.preconditioning import (
+    Preconditioner,
+    IdentityDiagonalPreconditioner
+)
 
 DEBUG_CONSTRAINED_SAMPLING = False
 
@@ -233,19 +237,69 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     def __init__(
             self,
             *args,
-            preconditioner=preconditioning.IdentityDiagonalPreconditioner(), # we need rotational symmetry
-            constraint_fn=None,
-            fwd_model=None,
-            init_obs_output=None,
-            levelset_handler = LevelSetHandlerQR(),
-            solver_options = {},
-            x_tols = {},
-            levelset_finder_settings = None,
+            preconditioner: Preconditioner = IdentityDiagonalPreconditioner(), # we need rotational symmetry
+            constraint_fn: Optional[Callable[[ArrayLike], jax.Array]] = None,
+            fwd_model: Optional[Callable[[ArrayLike], jax.Array]] = None,
+            init_obs_output: Optional[ArrayLike] = None,
+            levelset_handler: LevelSetHandler = LevelSetHandlerQR(),
+            solver_options: dict = {},
+            x_tols: dict = {},
+            levelset_finder_settings: Optional[bool | dict] = None,
             **kwargs
-        ):
+        ) -> None:
+        """Instantiate an :class:`AutoConstrainedRWMH` sampler.
+
+        :param args: Passed to the :class:`AutoStep` constructor.
+        :param Preconditioner preconditioner: only allows instances of class
+            :class:`IdentityDiagonalPreconditioner`.
+        :param Optional[Callable[[ArrayLike], jax.Array]] constraint_fn: user
+            provided function to constrain the sampler to the function's zero
+            levelset. This is equivalent to providing the same function as
+            `fwd_model` and additionally passing `init_obs_output=0`.
+        :param Optional[Callable[[ArrayLike], jax.Array]] fwd_model: constrain
+            the sampler to a levelset of this function, parametrized via the
+            `init_obs_output` argument.
+        :param Optional[ArrayLike] init_obs_output: output of `fwd_model` on
+            whose levelset we wish to constain the sampler. Under NumPyro's
+            vectorized sampling, it is possible to batch `num_chains` different
+            output values in order to simultaneously sample multiple levelsets.
+        :param LevelSetHandler levelset_handler: defines the method to project
+            velocities to tangent spaces along the level set. Defaults to the
+            QR-based approach described in [1] (:class:`LevelSetHandlerQR`). In
+            high-dimensional settings, it may be beneficial to switch to the
+            approach suggested in [2], based on the Cholesky decomposition
+            (:class:`LevelSetHandlerCholesky`), at the cost of less robustness
+            to high curvature models.
+        :param dict solver_options: passed to :func:`utils.newton`. Default
+            values are established based on the float type of the arguments and
+            the dimension.
+        :param dict x_tols: optional `dict` with `atol` and `rtol` values used
+            to detect difference in ambient space during reversibility check.
+            Default values are established based on the float type of the
+            arguments and the dimension.
+        :param Optional[bool | dict] levelset_finder_settings: if truthy,
+            an initial robust gradient descent (NADAMW) phase is employed to
+            find the desired level set. This is useful when the initial
+            parameters are far from the level set, since the Newton solver
+            struggles in this setting. Defaults to `None`; i.e., not used.
+            For additional control, the user may pass a `dict` with the same
+            structure as
+            `automcmc.optimization.DEFAULT_OPTIMIZE_FUN_SETTINGS['NADAMW']`.
+        :param kwargs: Passed to the :class:`AutoStep` constructor.
+
+
+        .. rubric:: References
+
+        [1] Zappa, E., Holmes-Cerfon, M. & Goodman, J. (2018).
+        Monte Carlo on manifolds: Sampling densities and integrating functions.
+        *Comm. Pure Appl. Math.*, 71, 2609-2647.
+
+        [2] Xu, K., & Holmes-Cerfon, M. (2024). Monte Carlo on manifolds in high
+        dimensions. *Journal of Computational Physics*, 506, 112939.
+        """
         super().__init__(*args,preconditioner=preconditioner,**kwargs)
         assert isinstance(
-            self.preconditioner, preconditioning.IdentityDiagonalPreconditioner
+            self.preconditioner, IdentityDiagonalPreconditioner
         ), "This method is justified only for `IdentityDiagonalPreconditioner`" \
           f" but I got instead {type(self.preconditioner)}"
 

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -110,14 +110,14 @@ class LevelSetHandler(metaclass=ABCMeta):
         return (PNv, v - PNv)
 
 
-class LevelSetHandlerChol(LevelSetHandler):
+class LevelSetHandlerCholesky(LevelSetHandler):
     """
     Handles the projection onto the normal space using an approach based on
     `jvp`, `vjp`, and the Cholesky decomposition of :math:`J_xJ_x^T` [1].
-    Its main benefit is that projections have cost :math:`O(2nm + m^2)` and
-    memory :math:`O(n+m^2)`. The linear scaling in `n` makes it ideal for
-    high-dimensional settings. However, the method suffers from low accuracy
-    issues when the level sets exhibit high curvature.
+    Its main benefit is that each operation has complexity at most linear
+    in `n` while only using :math:`O(n+m^2)` memory, making it ideal for
+    high-dimensional settings. However, the method exhibits low accuracy in the
+    presence of high curvature.
 
     .. rubric:: References
 
@@ -132,7 +132,7 @@ class LevelSetHandlerChol(LevelSetHandler):
             tol: ArrayLike
         ) -> LevelSetState:
         J, is_satisfied = self.get_jacobian_and_check_output(
-            fwd_model, x_base, obs_output, tol
+            fwd_model, obs_output, x_base, tol
         )
         chol = jax.lax.linalg.cholesky(jnp.inner(J,J))
         log_abs_det = -jnp.log(jnp.abs(jnp.diag(chol))).sum()
@@ -158,9 +158,9 @@ class LevelSetHandlerChol(LevelSetHandler):
         ) -> jax.Array:
         chol = lss.mat
         u = jax.jvp(fwd_model, (lss.x_base,), (v,))[-1]
-        t = jax.lax.linalg.triangular_solve(chol, u, lower=True) # == jnp.linalg.solve(cs.chol, u)
+        t = jax.lax.linalg.triangular_solve(chol, u, lower=True) # == jnp.linalg.solve(chol, u)
         w = jax.lax.linalg.triangular_solve(
-            chol, t, lower=True, transpose_a=True # == jnp.linalg.solve(cs.chol.T, t)
+            chol, t, lower=True, transpose_a=True # == jnp.linalg.solve(chol.T, t)
         )
         f_vjp = jax.vjp(fwd_model, lss.x_base)[-1]
         return f_vjp(w)[0]
@@ -187,7 +187,7 @@ class LevelSetHandlerQR(LevelSetHandler):
             tol: ArrayLike
         ) -> LevelSetState:
         J, is_satisfied = self.get_jacobian_and_check_output(
-            fwd_model, x_base, obs_output, tol
+            fwd_model, obs_output, x_base, tol
         )
         Q,R = jnp.linalg.qr(J.T)
         log_abs_det = -jnp.log(jnp.abs(jnp.diag(R))).sum()
@@ -199,14 +199,15 @@ class LevelSetHandlerQR(LevelSetHandler):
     #   P[N]v = J^T(JJ^T)^{-1}Jv
     # If J^T = QR, then JJ^T = R^TR and
     #   P[N]v = [QR(R^TR)^{-1}R^TQ^T]v = QQ^Tv
+    # Cost: O(mn)
     @staticmethod
     def proj_normal(
-            fwd_model: Callable[[ArrayLike], jax.Array],
+            _: Callable[[ArrayLike], jax.Array],
             lss: LevelSetState,
             v: ArrayLike
         ) -> jax.Array:
         Q = lss.mat
-        return Q @ jnp.dot(v,Q)
+        return Q @ jnp.dot(v,Q) # dot(v,Q) === Q.T@v
 
 
 ###############################################################################
@@ -233,9 +234,10 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             self,
             *args,
             preconditioner=preconditioning.IdentityDiagonalPreconditioner(), # we need rotational symmetry
-            constraint_fn=None, # aim is to target `constraint_fn=0`. Input var is x_flat.
+            constraint_fn=None,
             fwd_model=None,
             init_obs_output=None,
+            levelset_handler = LevelSetHandlerQR(),
             solver_options = {},
             x_tols = {},
             levelset_finder_settings = None,
@@ -260,9 +262,13 @@ class AutoConstrainedRWMH(autostep.AutoStep):
 
         self.fwd_model = fwd_model
         self.init_obs_output = 0 if init_obs_output is None else init_obs_output
+        self.levelset_handler = levelset_handler
         self.solver_options = solver_options
         self.x_tols = x_tols
-        if levelset_finder_settings is None:
+        if (
+            levelset_finder_settings and
+            (not isinstance(levelset_finder_settings, dict))
+            ):
             # shallow copy is enough since we only change `n_iter`
             levelset_finder_settings = (
                 optimization.DEFAULT_OPTIMIZE_FUN_SETTINGS['NADAMW'].copy()
@@ -286,8 +292,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         :return tuple[Any, ...]: projected vector, updated
             :class:`LevelSetState`, and solver diagnostics.
         """
-        # project to the feasible set in the normal directions at cs.x_base
-        #   solve for z: 0 = f(x + J^Tz) => set x' = x + J^Tz
+        # project to the feasible set in the normal directions at x_base
+        #   solve for z: y = f(x + J^Tz) => set x' = x + J^Tz
         # since J^Tz = (z^TJ)^T, we can use vector-Jacobian prods (vjp)
         f_val, f_vjp = jax.vjp(self.fwd_model, lss.x_base) # Jac[fwd-mod] == Jac[constr]
         z, *diagnostics, _ = utils.newton(
@@ -298,7 +304,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         x_flat += f_vjp(z)[0]
 
         # update the constraint state and return
-        lss = make_fwd_model_state(
+        lss = self.levelset_handler.make_levelset_state(
             self.fwd_model,
             lss.obs_output,
             x_flat,
@@ -309,6 +315,8 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     # preliminary pass with gradient descent on least-squares loss to get close to
     # levelset, as Newton fails when initialized too far away
     def find_levelset(self, x_flat, init_obs_output):
+        if not isinstance(self.levelset_finder_settings, dict):
+            return x_flat
         n_iter = self.levelset_finder_settings['n_iter']
         target_fun = lambda x: jnp.square(
             self.fwd_model(x) - init_obs_output
@@ -348,7 +356,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             self.x_tols['atol'] = self.solver_options['tol'] # this val already scales with size of problem so no need to scale again
 
         # initialize the forward model state
-        lss = make_fwd_model_state(
+        lss = self.levelset_handler.make_levelset_state(
             self.fwd_model,
             init_obs_output,
             x_flat,
@@ -378,7 +386,7 @@ class AutoConstrainedRWMH(autostep.AutoStep):
                 state.x, self.init_obs_output
             )
 
-        assert jnp.all(lss.cs.is_satisfied), \
+        assert jnp.all(lss.is_satisfied), \
             f"Cannot find feasible starting point. Solver output:\n{diagnostics}"
 
         # return updated state
@@ -390,9 +398,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     # sample and project to tangent space
     def refresh_aux_vars(self, rng_key, state, precond_state):
         return state._replace(
-            p_flat = proj_normal_tangent(
+            p_flat = self.levelset_handler.proj_normal_tangent(
                 self.fwd_model, # Jac[fwd-mod] == Jac[constraint]
-                state.idiosyncratic.cs,
+                state.idiosyncratic,
                 random.normal(rng_key, jnp.shape(state.p_flat))
             )[-1]
         )
@@ -402,9 +410,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
     #   - make the likelihood 0 when constraint is not satisfied, so that
     #     solver failures are handled gracefully by the autostep executors
     def postprocess_logprior_and_loglik(self, state, log_prior, log_lik):
-        cs = state.idiosyncratic.cs
-        log_prior += cs.log_abs_det
-        log_lik = jnp.where(cs.is_satisfied, log_lik, -jnp.inf)
+        lss = state.idiosyncratic
+        log_prior += lss.log_abs_det
+        log_lik = jnp.where(lss.is_satisfied, log_lik, -jnp.inf)
         return log_prior, log_lik
 
     # check closeness of ambient space vectors by using a symmetric check
@@ -438,13 +446,13 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             "exponents match: {}", passed, ordered=True
         )
         passed = jnp.logical_and(
-            passed, proposed_state.idiosyncratic.cs.is_satisfied
+            passed, proposed_state.idiosyncratic.is_satisfied
         )
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and prop state is feasible: {}", passed, ordered=True
         )
         passed = jnp.logical_and(
-            passed, roundtrip_state.idiosyncratic.cs.is_satisfied
+            passed, roundtrip_state.idiosyncratic.is_satisfied
         )
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and rt state is feasible: {}", passed, ordered=True
@@ -494,9 +502,9 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         # onto the tangent space at the new point
         # note: the displacement is on scale step_size * v, so we must divide
         # by the step size to get the right scale
-        v_flat = proj_normal_tangent(
+        v_flat = self.levelset_handler.proj_normal_tangent(
             self.fwd_model, # Jac[fwd-mod] == Jac[constraint]
-            lss.cs,
+            lss,
             x_flat_new - x_flat
         )[-1] / step_size
 

--- a/automcmc/optimization.py
+++ b/automcmc/optimization.py
@@ -17,19 +17,18 @@ from automcmc import utils
 def make_nadamw_solver(target_fun, solver_params, verbose):
     if verbose:
         print(f'NADAMW optimization loop.')
-    
+
     # build solver
     solver = optax.nadamw(**solver_params)
 
-    # build loop function and jit it
-    @jax.jit
+    # build loop function
     def step_fn(params, state):
         value, grad = jax.value_and_grad(target_fun)(params)
         updates, state = solver.update(grad, state, params)
         params = optax.apply_updates(params, updates)
         grad_norm = utils.pytree_norm(grad, ord=jnp.inf) # sup norm
         return params, state, value, grad_norm
-    
+
     return solver, step_fn
 
 
@@ -44,7 +43,6 @@ def make_lbfgs_solver(target_fun, solver_params, verbose):
 
     # build solver and loop function
     solver = optax.lbfgs(**solver_params)
-    @jax.jit
     def step_fn(params, opt_state):
         value, grad = cached_value_and_grad(params, state=opt_state)
         updates, opt_state = solver.update(
@@ -53,7 +51,7 @@ def make_lbfgs_solver(target_fun, solver_params, verbose):
         params = optax.apply_updates(params, updates)
         grad_norm = utils.pytree_norm(grad, ord=jnp.inf) # sup norm
         return params, opt_state, value, grad_norm
-    
+
     return solver, step_fn
 
 def optimization_loop(
@@ -61,24 +59,25 @@ def optimization_loop(
         step_fn,
         params,
         opt_state,
-        n_iter, 
+        n_iter,
         tol = None,
-        max_consecutive = 2, 
+        max_consecutive = 2,
         verbose = True
     ):
     if tol is None:
         tol = 10*jnp.finfo(jax.tree.leaves(params)[0].dtype).eps
-    
+
     value = old_value = target_fun(params)
     verbose and print(f'Initial energy: {value:.1e}')
     old_params = params
     grad_norm = value_abs_diff = params_diff_norm = jnp.full_like(value, 10*tol)
     n_consecutive = np.zeros((3,), np.int32) # one counter for each termination criterion
     n = 0
+    jit_step_fn = jax.jit(step_fn)
     with tqdm.tqdm(total=n_iter, disable=(not verbose)) as t:
         while (n < n_iter and np.all(n_consecutive < max_consecutive)):
             # take one optim step
-            params, opt_state, value, grad_norm = step_fn(params, opt_state)
+            params, opt_state, value, grad_norm = jit_step_fn(params, opt_state)
 
             # update termination indicators
             value_abs_diff = jnp.abs(value-old_value)
@@ -108,8 +107,8 @@ DEFAULT_OPTIMIZE_FUN_SETTINGS = {
 }
 
 def optimize_fun(
-        target_fun, 
-        init_params, 
+        target_fun,
+        init_params,
         settings = DEFAULT_OPTIMIZE_FUN_SETTINGS,
         verbose = True,
         **kwargs
@@ -120,10 +119,10 @@ def optimize_fun(
     to use NADAMW to find a good enough point for L-BFGS to take it from there.
     This is especially useful when working with lower precision floats such as
     `jnp.float32` (see e.g. [1]).
-    
+
     :param target_fun: Function to minimize
     :param init_params: Starting point
-    :param settings: Dictionary of settings passed to the solvers. See 
+    :param settings: Dictionary of settings passed to the solvers. See
         :data:`DEFAULT_OPTIMIZE_FUN_SETTINGS` for an example.
     :param verbose: Should we print info?
     :param kwargs: Passed to :func:`optimization_loop`
@@ -131,9 +130,9 @@ def optimize_fun(
 
     .. rubric:: References
 
-    .. [1] Kiyani, E., Shukla, K., Urbán, J. F., Darbon, J., & Karniadakis, 
-        G. E. (2025). Optimizing the optimizer for physics-informed neural 
-        networks and Kolmogorov-Arnold networks. *Computer Methods in Applied 
+    .. [1] Kiyani, E., Shukla, K., Urbán, J. F., Darbon, J., & Karniadakis,
+        G. E. (2025). Optimizing the optimizer for physics-informed neural
+        networks and Kolmogorov-Arnold networks. *Computer Methods in Applied
         Mechanics and Engineering, 446*, 118308.
     """
     # start with NADAMW
@@ -155,7 +154,7 @@ def optimize_fun(
         )
         if jnp.isfinite(value_nadamw) and value_nadamw<init_value:
             opt_params = opt_params_nadamw
-        
+
     # refine with L-BFGS
     if "L-BFGS" in settings:
         solver, step_fn = make_lbfgs_solver(
@@ -171,7 +170,7 @@ def optimize_fun(
             verbose=verbose,
             **kwargs
         )
-    
+
     # return lbfgs if better, explicitly handle nans (nan < x != nan)
     if jnp.isfinite(value_lbfgs) and value_lbfgs < value_nadamw:
         return opt_params_lbfgs

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -309,9 +309,9 @@ class TestConstrained(unittest.TestCase):
                 xs,ys,zs = mcmc.get_samples().T
                 xy_cdf = lambda q: (q*jnp.sqrt(1-q*q) + jnp.arcsin(q))/jnp.pi + 0.5 # thx 2 symbolic integration
                 z_cdf = np.square
-                self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.01)
-                self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.01)
-                self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.01)
+                self.assertGreater(stats.ks_1samp(xs, xy_cdf).pvalue, 0.001)
+                self.assertGreater(stats.ks_1samp(ys, xy_cdf).pvalue, 0.001)
+                self.assertGreater(stats.ks_1samp(zs, z_cdf).pvalue, 0.001)
 
 
     def test_sample_orthonormal(self):

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -9,9 +9,17 @@ from scipy import stats
 import jax
 from jax import numpy as jnp
 
-from automcmc import constrained,utils,preconditioning,selectors
+from automcmc import (
+    constrained,
+    utils,
+    preconditioning,
+    selectors,
+    optimization
+)
 from automcmc.constrained import LevelSetHandlerCholesky, LevelSetHandlerQR
 from numpyro.infer import MCMC
+
+TESTED_LEVELSET_HANDLERS = (LevelSetHandlerCholesky(), LevelSetHandlerQR())
 
 class TestConstrained(unittest.TestCase):
 
@@ -42,9 +50,7 @@ class TestConstrained(unittest.TestCase):
         m = (n+d)//2 # d(d+1)//2
         n_sim = 10
         rng_key = jax.random.key(1)
-        for levelset_handler in (
-            LevelSetHandlerCholesky(), LevelSetHandlerQR()
-            ):
+        for levelset_handler in TESTED_LEVELSET_HANDLERS:
             for n_rep in range(n_sim):
                 with self.subTest(
                     levelset_handler_type=type(levelset_handler), n_rep=n_rep,
@@ -311,42 +317,48 @@ class TestConstrained(unittest.TestCase):
     def test_sample_orthonormal(self):
         # matrices with orthonormal rows
         # Example 3 in Zappa & Holmes-Cerfon (2018)
-        # TODO: show that JJ^T is indeed constant (empirically true so far)
         constraint_fn=testutils.orthonormal_constraint
         potential_fn = lambda x: jnp.zeros_like(x,shape=()) # uniform
         d = 11
         n_dim = d*d
 
-        # mcmc sampling
-        rng_key, init_key = jax.random.split(jax.random.key(53))
-        init_params=jax.random.normal(init_key, (n_dim,)) # init in interior of cone
-        n_warm, n_keep = utils.split_n_rounds(16)
-        thinning=2**6 # %ESS ~ 1/64
-        extra_fields = ('idiosyncratic.log_abs_det',)
-        rng_key, mcmc_key = jax.random.split(rng_key)
-        kernel = constrained.AutoConstrainedRWMH(
-            potential_fn=potential_fn,
-            constraint_fn=constraint_fn,
-            solver_options={'mode': 'direct'},
-            init_base_step_size = 0.28, # in paper
-            selector = selectors.FixedStepSizeSelector()
-        )
-        mcmc = MCMC(
-            kernel,
-            num_warmup=n_warm,
-            num_samples=n_keep,
-            thinning=thinning,
-            progress_bar=False
-        )
-        mcmc.run(
-            mcmc_key, init_params=init_params, extra_fields=extra_fields
-        )
-        log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-        self.assertLess(log_abs_det.std(), 0.05)
+        for levelset_handler in TESTED_LEVELSET_HANDLERS:
+            with self.subTest(levelset_handler_type=type(levelset_handler)):
+                # mcmc sampling
+                rng_key, init_key = jax.random.split(jax.random.key(53))
+                init_params=jax.random.normal(init_key, (n_dim,)) # init in interior of cone
+                n_warm, n_keep = utils.split_n_rounds(13)
+                thinning=2**6 # %ESS ~ 1/64
+                extra_fields = ('idiosyncratic.log_abs_det',)
+                rng_key, mcmc_key = jax.random.split(rng_key)
+                kernel = constrained.AutoConstrainedRWMH(
+                    potential_fn=potential_fn,
+                    constraint_fn=constraint_fn,
+                    solver_options={'mode': 'direct'},
+                    init_base_step_size = 0.28, # in paper
+                    selector = selectors.FixedStepSizeSelector(),
+                    levelset_handler=levelset_handler
+                )
+                mcmc = MCMC(
+                    kernel,
+                    num_warmup=n_warm,
+                    num_samples=n_keep,
+                    thinning=thinning,
+                    progress_bar=False
+                )
+                mcmc.run(
+                    mcmc_key, init_params=init_params, extra_fields=extra_fields
+                )
+                log_abs_det = next(iter((mcmc.get_extra_fields().values())))
+                self.assertLess(log_abs_det.std(), 0.05)
 
-        # ks test for normality of traces of the matrices
-        traces = jax.vmap(lambda v: jnp.diag(v.reshape((d,d))).sum())(mcmc.get_samples())
-        self.assertGreater(stats.ks_1samp(traces, stats.norm.cdf).pvalue, 0.01)
+                # ks test for normality of traces of the matrices
+                traces = jax.vmap(
+                    lambda v: jnp.diag(v.reshape((d,d))).sum()
+                )(mcmc.get_samples())
+                self.assertGreater(
+                    stats.ks_1samp(traces, stats.norm.cdf).pvalue, 0.01
+                )
 
     def test_constrained_vectorized(self):
         # params
@@ -410,6 +422,68 @@ class TestConstrained(unittest.TestCase):
         self.assertTrue(
             jnp.allclose(hist[0], angles.size/10, rtol=0.15)
         )
+
+    def test_mrna(self):
+        def prior_potential(x):
+            assert x.shape == (4,)
+            lt0, lkm0, lbeta, ldelta = x
+            ok = jnp.logical_and(lt0 > -2, lt0 < 1)
+            ok = jnp.logical_and(ok, jnp.logical_and(lkm0 > -5, lkm0 < 5))
+            ok = jnp.logical_and(ok, jnp.logical_and(lbeta > -5, lbeta < 5))
+            ok = jnp.logical_and(ok, jnp.logical_and(ldelta > -5, ldelta < 5))
+            return jnp.where(ok, 0, jnp.inf)
+
+        def ode_solution(km0, beta, delta, dt):
+            abs_diff = jnp.abs(delta-beta)
+            exp_prod = jnp.exp(-jnp.minimum(delta,beta)*dt)*jnp.expm1(-abs_diff*dt)
+            return -(km0/abs_diff)*exp_prod
+
+        def make_fwd_model(measured_times):
+            assert len(measured_times) < 4
+            def fwd_model(x):
+                assert x.shape == (4,)
+                t0, km0, beta, delta = 10**x
+                rel_ts = jax.nn.relu(measured_times - t0)
+                return ode_solution(km0, beta, delta, rel_ts)
+
+            return fwd_model
+
+        # define settings
+        rng_key = jax.random.key(6)
+        n_rounds = 14
+        thinning = 2**4
+        n_warm, n_keep = utils.split_n_rounds(n_rounds)
+        measured_times = jnp.array((4.0,8.0,16.0))
+        fwd_model = make_fwd_model(measured_times)
+
+        # simulate an observation by using a given point in input space
+        true_lambda = jnp.array(
+            [0.18858075,  1.1060505, -2.875724, -0.7061024]
+        )
+        init_obs_output = fwd_model(true_lambda)
+
+        # define initial parameters and sampler
+        rng_key, init_key, mcmc_key = jax.random.split(rng_key,3)
+        init_params = jax.random.uniform(init_key,(4,),minval=-1)
+        levelset_finder_settings=(
+            optimization.DEFAULT_OPTIMIZE_FUN_SETTINGS['NADAMW'].copy()
+        )
+        levelset_finder_settings['n_iter'] = 2**12
+        kernel = constrained.AutoConstrainedRWMH(
+            potential_fn=prior_potential,
+            fwd_model=fwd_model,
+            init_obs_output=init_obs_output,
+            levelset_finder_settings=levelset_finder_settings
+        )
+        mcmc = MCMC(
+            kernel,
+            num_warmup=n_warm,
+            num_samples=n_keep,
+            thinning=thinning,
+            progress_bar=False
+        )
+        mcmc.run(mcmc_key, init_params=init_params)
+        assert True
 
 
 if __name__ == '__main__':

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -353,8 +353,8 @@ class TestConstrained(unittest.TestCase):
         n_chains = 64
         n_dim = 2
         rng_key = jax.random.key(9)
-        n_warm, n_keep = utils.split_n_rounds(10)
-        thinning=16
+        n_warm, n_keep = utils.split_n_rounds(13)
+        thinning=2**3
 
         # define an equally spaced grid in [0,1]
         # check the Riemann integral recovers the truth (2/3) for expected radius
@@ -408,7 +408,7 @@ class TestConstrained(unittest.TestCase):
         angles = jnp.arctan2(samples[:,:,0],samples[:,:,1]).flatten()
         hist = jnp.histogram(angles,bins=jnp.linspace(-jnp.pi, jnp.pi, 11))
         self.assertTrue(
-            jnp.allclose(hist[0], samples.size/(10*n_dim), rtol=0.1)
+            jnp.allclose(hist[0], angles.size/10, rtol=0.15)
         )
 
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -10,6 +10,7 @@ import jax
 from jax import numpy as jnp
 
 from automcmc import constrained,utils,preconditioning,selectors
+from automcmc.constrained import LevelSetHandlerCholesky, LevelSetHandlerQR
 from numpyro.infer import MCMC
 
 class TestConstrained(unittest.TestCase):
@@ -38,37 +39,52 @@ class TestConstrained(unittest.TestCase):
     def test_proj_normal_tangent(self):
         d = 3
         n = d*d
+        m = (n+d)//2 # d(d+1)//2
         n_sim = 10
         rng_key = jax.random.key(1)
-        for _ in range(n_sim):
-            X = jnp.array(stats.ortho_group.rvs(dim=d,)) # iid sample SO(3)
-            constraint_fn = testutils.orthonormal_constraint
-            tol = utils.newton_default_tol(X)
-            cs = constrained.make_constraint_state(constraint_fn,X.flatten(),tol)
-            self.assertTrue(cs.is_satisfied)
-            m = cs.chol.shape[0]
-            self.assertEqual(m, d*(d+1)//2)
-            J = jax.jacobian(constraint_fn)(cs.x_base)
-            gram_mat = jnp.inner(J,J)
-            self.assertLess(
-                jnp.linalg.norm(gram_mat - jnp.inner(cs.chol,cs.chol)), tol
-            )
-            self.assertAlmostEqual(
-                cs.log_abs_det,
-                -0.5*jnp.log(jnp.abs(jnp.linalg.det(gram_mat))),
-                delta = 0.001
-            )
-            rng_key, v_key = jax.random.split(rng_key)
-            v = jax.random.normal(v_key, (n,))
-            PNv,PTv = constrained.proj_normal_tangent(constraint_fn,cs,v)
-            self.assertTrue(jnp.allclose(v, PNv+PTv))
-            jvp_val = jax.jvp(constraint_fn, (cs.x_base,), (PTv,))[-1] # PTv \perp to every row of Jac
-            self.assertLess(jnp.abs(jvp_val).max(), 0.01)
-            jvp_val_dumb = J@PTv
-            self.assertTrue(
-                jnp.allclose(jvp_val, jvp_val_dumb, atol=tol, rtol=0.01),
-                f"jvp_val={jvp_val} but J@PTv={jvp_val_dumb}"
-            )
+        for levelset_handler in (
+            LevelSetHandlerCholesky(), LevelSetHandlerQR()
+            ):
+            for n_rep in range(n_sim):
+                with self.subTest(
+                    levelset_handler_type=type(levelset_handler), n_rep=n_rep,
+                ):
+                    X = jnp.array(stats.ortho_group.rvs(dim=d,)) # iid sample SO(3)
+                    constraint_fn = testutils.orthonormal_constraint
+                    tol = utils.newton_default_tol(X)
+                    lss = levelset_handler.make_levelset_state(
+                        constraint_fn, 0, X.flatten(), tol
+                    )
+                    self.assertTrue(lss.is_satisfied)
+                    J = jax.jacobian(constraint_fn)(lss.x_base)
+                    gram_mat = jnp.inner(J,J)
+                    if isinstance(levelset_handler, LevelSetHandlerCholesky):
+                        self.assertEqual((m,m), lss.mat.shape)
+                        self.assertLess(
+                            jnp.linalg.norm(gram_mat - jnp.inner(lss.mat,lss.mat)),
+                            tol
+                        )
+                    else:
+                        self.assertEqual((n,m), lss.mat.shape)
+
+                    self.assertAlmostEqual(
+                        lss.log_abs_det,
+                        -0.5*jnp.log(jnp.abs(jnp.linalg.det(gram_mat))),
+                        delta = 0.002
+                    )
+                    rng_key, v_key = jax.random.split(rng_key)
+                    v = jax.random.normal(v_key, (n,))
+                    PNv, PTv = levelset_handler.proj_normal_tangent(
+                        constraint_fn, lss, v
+                    )
+                    self.assertTrue(jnp.allclose(v, PNv+PTv))
+                    jvp_val = jax.jvp(constraint_fn, (lss.x_base,), (PTv,))[-1] # PTv \perp to every row of Jac
+                    self.assertLess(jnp.abs(jvp_val).max(), 0.01)
+                    jvp_val_dumb = J@PTv
+                    self.assertTrue(
+                        jnp.allclose(jvp_val, jvp_val_dumb, atol=tol, rtol=0.01),
+                        f"jvp_val={jvp_val} but J@PTv={jvp_val_dumb}"
+                    )
 
 
     def test_constrained_involution(self):
@@ -101,7 +117,7 @@ class TestConstrained(unittest.TestCase):
                     init_params = jax.random.normal(randn_key, (n_dim,))
                     state = kernel.init(init_key, 0, init_params, (), {})
                     tol = kernel.solver_options['tol']
-                    self.assertTrue(state.idiosyncratic.cs.is_satisfied)
+                    self.assertTrue(state.idiosyncratic.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(constraint_fn(state.x)), tol
                     )
@@ -117,7 +133,7 @@ class TestConstrained(unittest.TestCase):
                     )
                     self.assertAlmostEqual(
                         state.log_prior,
-                        state.idiosyncratic.cs.log_abs_det - potential_fn(state.x),
+                        state.idiosyncratic.log_abs_det - potential_fn(state.x),
                         delta=tol
                     )
 
@@ -125,7 +141,7 @@ class TestConstrained(unittest.TestCase):
                     state_half = kernel.involution_main(
                         step_size, state, precond_state
                     )
-                    self.assertTrue(state_half.idiosyncratic.cs.is_satisfied)
+                    self.assertTrue(state_half.idiosyncratic.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(constraint_fn(state_half.x)),
                         tol
@@ -145,7 +161,7 @@ class TestConstrained(unittest.TestCase):
                     state_onehalf = kernel.involution_main(
                         step_size, state_one, precond_state
                     )
-                    self.assertTrue(state_onehalf.idiosyncratic.cs.is_satisfied)
+                    self.assertTrue(state_onehalf.idiosyncratic.is_satisfied)
                     self.assertLess(
                         utils.newton_fn_value_err(
                             constraint_fn(state_onehalf.x)
@@ -206,7 +222,7 @@ class TestConstrained(unittest.TestCase):
         n_warm, n_keep = utils.split_n_rounds(15)
         thinning=32 # %ESS ~ 1/32
         init_params = jnp.ones(3) # init outside level set on purpose
-        extra_fields = ('idiosyncratic.cs.log_abs_det',)
+        extra_fields = ('idiosyncratic.log_abs_det',)
         for sel in (
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
@@ -228,7 +244,7 @@ class TestConstrained(unittest.TestCase):
             )
             mcmc.run(mcmc_key,init_params=init_params, extra_fields=extra_fields)
             log_abs_det = next(iter((mcmc.get_extra_fields().values())))
-            self.assertLess(jnp.abs(log_abs_det).max(), kernel.x_tols['atol']) # check that they are all ~0
+            self.assertLess(jnp.abs(log_abs_det).max(), 2*kernel.x_tols['atol']) # check that they are all ~0
             samples = mcmc.get_samples()
             self.assertLessEqual(
                 utils.newton_fn_value_err(jax.vmap(constraint_fn)(samples)),
@@ -254,7 +270,7 @@ class TestConstrained(unittest.TestCase):
         init_params=jnp.full((3,), 0.5) # init in interior of cone
         n_warm, n_keep = utils.split_n_rounds(14)
         thinning=16 # %ESS ~ 1/16
-        extra_fields = ('idiosyncratic.cs.log_abs_det',)
+        extra_fields = ('idiosyncratic.log_abs_det',)
         for sel in (
             selectors.FixedStepSizeSelector(),
             selectors.DeterministicSymmetricSelector(),
@@ -306,7 +322,7 @@ class TestConstrained(unittest.TestCase):
         init_params=jax.random.normal(init_key, (n_dim,)) # init in interior of cone
         n_warm, n_keep = utils.split_n_rounds(16)
         thinning=2**6 # %ESS ~ 1/64
-        extra_fields = ('idiosyncratic.cs.log_abs_det',)
+        extra_fields = ('idiosyncratic.log_abs_det',)
         rng_key, mcmc_key = jax.random.split(rng_key)
         kernel = constrained.AutoConstrainedRWMH(
             potential_fn=potential_fn,


### PR DESCRIPTION
- Add a short preliminary gradient descent for least squares loss for finding points closer to levelset. Newton tends to fail when initialized too far away.
- Revive the QR approach and set as default, as it is much more accurate in the high curvature regime.
- Add mRNA test that needs the gradient descent initialization
- Use the opportunity to refactor the code