### PR TITLE
constrained: use step-size in velocity equality check

### DIFF
--- a/automcmc/autostep.py
+++ b/automcmc/autostep.py
@@ -79,8 +79,10 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
 
     def reversibility_check(
             self,
-            fwd_exponent: int,
-            bwd_exponent: int,
+            fwd_exponent: ArrayLike,
+            bwd_exponent: ArrayLike,
+            fwd_step_size: ArrayLike,
+            bwd_step_size: ArrayLike,
             initial_state: AutoMCMCState,
             proposed_state: AutoMCMCState,
             roundtrip_state: Optional[AutoMCMCState]
@@ -92,6 +94,8 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
 
         :param fwd_exponent: Forward exponent.
         :param bwd_exponent: Backward exponent.
+        :param fwd_step_size: Forward step size.
+        :param bwd_step_size: Backward step size.
         :param initial_state: Initial sampler state.
         :param proposed_state: Proposed state.
         :param roundtrip_state: Roundtrip state.
@@ -179,6 +183,8 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         reversibility_passed = self.reversibility_check(
             fwd_exponent,
             bwd_exponent,
+            fwd_step_size,
+            bwd_step_size,
             state,
             proposed_state,
             self.maybe_build_roundtrip_state(

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -489,28 +489,37 @@ class AutoConstrainedRWMH(autostep.AutoStep):
 
     def reversibility_check(
             self,
-            fwd_exponent: int,
-            bwd_exponent: int,
+            fwd_exponent: ArrayLike,
+            bwd_exponent: ArrayLike,
+            fwd_step_size: ArrayLike,
+            bwd_step_size: ArrayLike,
             initial_state: AutoMCMCState,
             proposed_state: AutoMCMCState,
             roundtrip_state: AutoMCMCState
         ) -> bool:
+        # std autostep check of exponents
         passed = fwd_exponent == bwd_exponent
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "exponents match: {}", passed, ordered=True
         )
+
+        # check proposed state is feasible
         passed = jnp.logical_and(
             passed, proposed_state.idiosyncratic.is_satisfied
         )
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and prop state is feasible: {}", passed, ordered=True
         )
+
+        # check roundtrip state is feasible
         passed = jnp.logical_and(
             passed, roundtrip_state.idiosyncratic.is_satisfied
         )
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and rt state is feasible: {}", passed, ordered=True
         )
+
+        # check flattened init and rt x values are close
         passed = jnp.logical_and(
             passed,
             self.close_in_ambient_space(
@@ -521,15 +530,26 @@ class AutoConstrainedRWMH(autostep.AutoStep):
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and rt state is close to init: {}", passed, ordered=True
         )
+
+        # check init and rt velocities values are close
+        # This check is not mentioned in the papers, but it is required by the
+        # autostep framework since the relevant involution acts on both x and v
+        # It may be possible to show that x_rt == x_init implies the velocities
+        # match, but it's not straightforward...
+        # Note: need to scale by step size, as this is the actual vector used
+        # in the involution (otherwise we get a lot of false positives)
         passed = jnp.logical_and(
             passed,
             self.close_in_ambient_space(
-                initial_state.p_flat, roundtrip_state.p_flat
+                fwd_step_size * initial_state.p_flat,
+                bwd_step_size * roundtrip_state.p_flat
             )
         )
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "and rt vel is close to init: {}", passed, ordered=True
         )
+
+        # if debugging, print all three states
         DEBUG_CONSTRAINED_SAMPLING and jax.debug.print(
             "\ninit_st={}\n\nprop_st={}\n\nrt_st={}",
             initial_state, proposed_state, roundtrip_state,

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -468,7 +468,7 @@ class TestConstrained(unittest.TestCase):
         levelset_finder_settings=(
             optimization.DEFAULT_OPTIMIZE_FUN_SETTINGS['NADAMW'].copy()
         )
-        levelset_finder_settings['n_iter'] = 2**12
+        levelset_finder_settings['n_iter'] = 2**11
         kernel = constrained.AutoConstrainedRWMH(
             potential_fn=prior_potential,
             fwd_model=fwd_model,


### PR DESCRIPTION
it's the actual vector we care about and also avoids some false positives