### PR TITLE
Minor improvements to constrained sampling

### DIFF
--- a/automcmc/autostep.py
+++ b/automcmc/autostep.py
@@ -42,6 +42,12 @@ class AutoStep(AutoMCMC, metaclass=ABCMeta):
         """
         pass
 
+    # all but the constrained sampler use involutions that are guaranteed to
+    # succeed, so we don't need to build the roundtrip state to check if it
+    # matches the initial state
+    def maybe_get_roundtrip_state(self, step_size, next_state, precond_state):
+        return None
+
     def auto_step_size(self, state, selector_params, precond_state):
         """
         Find an appropriate step size using the criterion defined by the

--- a/automcmc/constrained.py
+++ b/automcmc/constrained.py
@@ -517,6 +517,11 @@ class AutoConstrainedRWMH(autostep.AutoStep):
             x, y, self.x_tols['rtol'], self.x_tols['atol']
         )
 
+    # need to actually build the roundtrip state because involution is not
+    # guaranteed to succeed
+    def maybe_get_roundtrip_state(self, step_size, next_state, precond_state):
+        return self.involution(step_size, next_state, precond_state)
+
     def reversibility_check(
             self,
             initial_state: AutoMCMCState,

--- a/automcmc/selectors.py
+++ b/automcmc/selectors.py
@@ -148,12 +148,10 @@ class AcceptProbBracketingSelector(StepSizeSelector, metaclass=ABCMeta):
                 precond_state
             )
 
-            # roundtrip involution, no need to update log joint
-            # note: this is only needed for the next step. For all current
-            # samplers except constrained, the reversibility returns True
-            # always. Therefore, building the roundtrip_state should be
-            # eliminated as dead code by the JIT compiler
-            roundtrip_state = kernel.involution(
+            # roundtrip involution (no need to update log joint)
+            # this is a no-op if sampler uses an involution that is guaranteed
+            # to succeed
+            roundtrip_state = kernel.maybe_get_roundtrip_state(
                 step_size, next_state, precond_state
             )
 

--- a/automcmc/utils.py
+++ b/automcmc/utils.py
@@ -85,7 +85,7 @@ def close_in_norm(
     ) -> jax.Array:
     """
     Check closeness of two arrays by comparing the norm of their difference to
-    the maximum of their individual norms
+    the minimum of their individual norms.
 
     :param ArrayLike x: first array to compare.
     :param ArrayLike y: second array to compare.
@@ -96,7 +96,7 @@ def close_in_norm(
     diff_norm = jnp.linalg.norm(x-y)
     x_norm = jnp.linalg.norm(x)
     y_norm = jnp.linalg.norm(y)
-    return diff_norm < jnp.maximum(atol, rtol*jnp.maximum(x_norm, y_norm))
+    return diff_norm < jnp.maximum(atol, rtol*jnp.minimum(x_norm, y_norm))
 
 def newton_default_tol(x: ArrayLike) -> jax.Array:
     # for float64, eps^(0.32) ~ 1e-5 which is the std tol use in most packages


### PR DESCRIPTION
- use min instead of max in equality check -> stricter
- skip building the roundtrip state in samplers with guaranteed involution (i.e., all except constrained). Before we relied on JIT compiler optimizing out this part as dead code, but since the sample step is sometimes run outside of JIT context, that part of the code may have been taking up memory regardless.